### PR TITLE
UTIL-564: validate config on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ cd remote-commands-handler
 
 3. Install dependencies:
 
+```bash
+poetry install
+```
+
 ## Running the Tests
 
 This project uses pytest for unit testing.
@@ -34,7 +38,9 @@ To run the tests:
 
 ```bash
 poetry install
+poetry run pytest
 ```
+
 ## Usage
 To run the application:
 
@@ -44,12 +50,26 @@ poetry run python main.py
 
 or
 ```bash
-docker run -e CONFIGURATION_PATH=config/configuration.yaml ghcr.io/evergenenergy/remote-comands-handler:latest
-``````
+docker run -e CONFIGURATION_PATH=config/configuration.yaml ghcr.io/evergenenergy/remote-commands-handler:latest
+```
+
+Once `main.py` is running, you can publish JSON payloads to your MQTT broker and these will be transformed into commands sent to Modbus. The expected JSON format is:
+
+```
+{
+    "action": "firstCoilSlot",
+    "value": 1
+}
+```
 
 ## Configuration
 
-Modify the config.yml file to match your MQTT and Modbus settings.
+You will need to modify the `configuration.yaml` file to match your MQTT and Modbus settings.
+
+- Provide the required host and port number for your MQTT broker in the `mqtt_settings` section, as well as the topic to subscribe to, and for your Modbus server in the `modbus_settings` section
+- The `modbus_mappings` section allows you to configure the coils and holding registers available on your Modbus server
+- Each entry under `coils` and `holding_registers` refers to a space where Modbus will store data. The `name` for each entry will correspond to the `action` of your JSON payloads. The `address` for each entry identifies the relevant location within the Modbus server.
+- For holding registers, you must also specify the `data_type` and `byte_order` for each register.
 
 ## Contributing
 

--- a/app/configuration.py
+++ b/app/configuration.py
@@ -79,7 +79,7 @@ class Configuration:
             yaml_data = path_to_yaml_data(path)
         except yaml.YAMLError as exc:
             msg = "Error parsing YAML file"
-            if hasattr(exc, 'problem_mark'):
+            if hasattr(exc, "problem_mark"):
                 msg = f"Error encountered parsing YAML {str(exc.problem_mark)}"
             raise ConfigurationFileInvalidError(msg)
 
@@ -146,31 +146,40 @@ def _holding_register_from_yaml_data(data):
             register["name"],
             memory_order,
             register["data_type"],
-            register.get("scale",1.0),
+            register.get("scale", 1.0),
             register["address"],
         )
         holding_registers.append(register)
 
     return holding_registers
 
+
 def _validate_config(config: dict):
-    required_settings = ('mqtt_settings', 'modbus_settings', 'modbus_mapping')
+    required_settings = ("mqtt_settings", "modbus_settings", "modbus_mapping")
     try:
         for req_key in required_settings:
-            assert req_key in config, f"No {req_key!r} section provided in configuration"
+            assert (
+                req_key in config
+            ), f"No {req_key!r} section provided in configuration"
 
-        mapping = config['modbus_mapping']
-        keys_defined = sum([len(mapping.get(k,[])) for k in ('holding_registers', 'coils')])
+        mapping = config["modbus_mapping"]
+        keys_defined = sum(
+            [len(mapping.get(k, [])) for k in ("holding_registers", "coils")]
+        )
         assert keys_defined > 0, "No keys defined in holding_registers or coils"
 
-        section_keys = ['name', 'address']
-        for index, ref in enumerate(mapping.get('coils', [])):
+        section_keys = ["name", "address"]
+        for index, ref in enumerate(mapping.get("coils", [])):
             for key in section_keys:
-                assert key in ref, f"Coil reference #{index} has no config setting for {key!r}"
+                assert (
+                    key in ref
+                ), f"Coil reference #{index} has no config setting for {key!r}"
 
-        section_keys.extend(['byte_order', 'data_type'])
-        for index, ref in enumerate(mapping.get('holding_registers', [])):
+        section_keys.extend(["byte_order", "data_type"])
+        for index, ref in enumerate(mapping.get("holding_registers", [])):
             for key in section_keys:
-                assert key in ref, f"Holding register reference #{index} has no config setting for {key!r}"
+                assert (
+                    key in ref
+                ), f"Holding register reference #{index} has no config setting for {key!r}"
     except AssertionError as ex:
         raise ConfigurationFileInvalidError(ex)

--- a/app/configuration.py
+++ b/app/configuration.py
@@ -26,7 +26,7 @@ import yaml
 from app.memory_order import MemoryOrder
 
 
-from app.exceptions import ConfigurationFileNotFoundError
+from app.exceptions import ConfigurationFileNotFoundError, ConfigurationFileInvalidError
 
 
 @dataclass
@@ -74,7 +74,17 @@ class Configuration:
     def from_file(cls, path: str):
         if not os.path.exists(path):
             raise ConfigurationFileNotFoundError(path)
-        yaml_data = path_to_yaml_data(path)
+
+        try:
+            yaml_data = path_to_yaml_data(path)
+        except yaml.YAMLError as exc:
+            msg = "Error parsing YAML file"
+            if hasattr(exc, 'problem_mark'):
+                msg = f"Error encountered parsing YAML {str(exc.problem_mark)}"
+            raise ConfigurationFileInvalidError(msg)
+
+        _validate_config(yaml_data)
+
         coils = _coils_data_from_yaml_data(yaml_data)
         holding_registers = _holding_register_from_yaml_data(yaml_data)
         mqtt_settings = _mqtt_settings_from_yaml_data(yaml_data)
@@ -136,9 +146,31 @@ def _holding_register_from_yaml_data(data):
             register["name"],
             memory_order,
             register["data_type"],
-            register["scale"],
+            register.get("scale",1.0),
             register["address"],
         )
         holding_registers.append(register)
 
     return holding_registers
+
+def _validate_config(config: dict):
+    required_settings = ('mqtt_settings', 'modbus_settings', 'modbus_mapping')
+    try:
+        for req_key in required_settings:
+            assert req_key in config, f"No {req_key!r} section provided in configuration"
+
+        mapping = config['modbus_mapping']
+        keys_defined = sum([len(mapping.get(k,[])) for k in ('holding_registers', 'coils')])
+        assert keys_defined > 0, "No keys defined in holding_registers or coils"
+
+        section_keys = ['name', 'address']
+        for index, ref in enumerate(mapping.get('coils', [])):
+            for key in section_keys:
+                assert key in ref, f"Coil reference #{index} has no config setting for {key!r}"
+
+        section_keys.extend(['byte_order', 'data_type'])
+        for index, ref in enumerate(mapping.get('holding_registers', [])):
+            for key in section_keys:
+                assert key in ref, f"Holding register reference #{index} has no config setting for {key!r}"
+    except AssertionError as ex:
+        raise ConfigurationFileInvalidError(ex)

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,5 +1,3 @@
-"""Exception classes for configuration-related errors."""
-
 
 class ConfigurationFileNotFoundError(Exception):
     """Exception raised when the configuration file is not found."""
@@ -8,3 +6,9 @@ class ConfigurationFileNotFoundError(Exception):
         self.path = path
         self.message = message + path
         super().__init__(self.message)
+
+class ConfigurationFileInvalidError(Exception):
+    """Exception raised when the configuration file contains errors."""
+
+    def __init__(self, message="Configuration file contains errors: "):
+        super().__init__(message)

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,4 +1,3 @@
-
 class ConfigurationFileNotFoundError(Exception):
     """Exception raised when the configuration file is not found."""
 
@@ -6,6 +5,7 @@ class ConfigurationFileNotFoundError(Exception):
         self.path = path
         self.message = message + path
         super().__init__(self.message)
+
 
 class ConfigurationFileInvalidError(Exception):
     """Exception raised when the configuration file contains errors."""

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,3 +1,6 @@
+"""Exception classes for configuration-related errors."""
+
+
 class ConfigurationFileNotFoundError(Exception):
     """Exception raised when the configuration file is not found."""
 

--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ from pymodbus.client import ModbusTcpClient
 from app.modbus_client import ModbusClient
 from app.mqtt_client import MqttClient
 from app.configuration import Configuration, ModbusSettings, MqttSettings
+from app.exceptions import ConfigurationFileNotFoundError, ConfigurationFileInvalidError
 
 
 def handle_args():
@@ -127,7 +128,12 @@ def main():
     logging.info("Starting service")
     args = handle_args()
 
-    configuration = get_configuration_with_overrides(args)
+    try:
+        configuration = get_configuration_with_overrides(args)
+    except (ConfigurationFileNotFoundError, ConfigurationFileInvalidError) as ex:
+        logging.info(ex)
+        logging.error("Error retrieving configuration, exiting")
+        sys.exit(1)
 
     modbus_client = setup_modbus_client(configuration)
     mqtt_client = setup_mqtt_client(configuration)

--- a/tests/config/configuration_test.py
+++ b/tests/config/configuration_test.py
@@ -23,7 +23,7 @@ def test_throws_exception_when_configuration_file_not_found():
 
 def test_throws_exception_when_configuration_file_has_syntax_errors():
     bad_yaml_path = "/tmp/bad.yaml"
-    with open(bad_yaml_path, 'w') as bad:
+    with open(bad_yaml_path, "w") as bad:
         bad.write("not actually yaml")
     with pytest.raises(ConfigurationFileInvalidError):
         Configuration.from_file(bad_yaml_path)

--- a/tests/config/configuration_test.py
+++ b/tests/config/configuration_test.py
@@ -11,7 +11,7 @@ from app.configuration import (
     ModbusSettings,
     MqttSettings,
     path_to_yaml_data,
-    _validate_config
+    _validate_config,
 )
 from app.exceptions import ConfigurationFileNotFoundError, ConfigurationFileInvalidError
 
@@ -20,9 +20,11 @@ def test_throws_exception_when_configuration_file_not_found():
     with pytest.raises(ConfigurationFileNotFoundError):
         Configuration.from_file("./tests/config/bad-example_configuration.yaml")
 
+
 def test_throws_exception_when_configuration_file_has_syntax_errors():
     with pytest.raises(ConfigurationFileInvalidError):
         Configuration.from_file("./tests/config/invalid_syntax_configuration.yaml")
+
 
 def test_get_coil():
     configuration = Configuration.from_file(_config_path())
@@ -107,8 +109,8 @@ def test_get_registers():
 
     assert holding_registers == configuration.get_holding_registers()
 
-def test_validate_config_data():
 
+def test_validate_config_data():
     config = path_to_yaml_data(_config_path())
 
     for key in ("modbus_settings", "mqtt_settings", "modbus_mapping"):
@@ -119,6 +121,6 @@ def test_validate_config_data():
 
     for datatype in ("coils", "holding_registers"):
         c = config.copy()
-        del c["modbus_mapping"][datatype][0]['address']
+        del c["modbus_mapping"][datatype][0]["address"]
         with pytest.raises(ConfigurationFileInvalidError):
             _validate_config(c)

--- a/tests/config/configuration_test.py
+++ b/tests/config/configuration_test.py
@@ -22,8 +22,12 @@ def test_throws_exception_when_configuration_file_not_found():
 
 
 def test_throws_exception_when_configuration_file_has_syntax_errors():
+    bad_yaml_path = "/tmp/bad.yaml"
+    with open(bad_yaml_path, 'w') as bad:
+        bad.write("not actually yaml")
     with pytest.raises(ConfigurationFileInvalidError):
-        Configuration.from_file("./tests/config/invalid_syntax_configuration.yaml")
+        Configuration.from_file(bad_yaml_path)
+    os.remove(bad_yaml_path)
 
 
 def test_get_coil():

--- a/tests/config/configuration_test.py
+++ b/tests/config/configuration_test.py
@@ -10,14 +10,19 @@ from app.configuration import (
     HoldingRegister,
     ModbusSettings,
     MqttSettings,
+    path_to_yaml_data,
+    _validate_config
 )
-from app.exceptions import ConfigurationFileNotFoundError
+from app.exceptions import ConfigurationFileNotFoundError, ConfigurationFileInvalidError
 
 
 def test_throws_exception_when_configuration_file_not_found():
     with pytest.raises(ConfigurationFileNotFoundError):
         Configuration.from_file("./tests/config/bad-example_configuration.yaml")
 
+def test_throws_exception_when_configuration_file_has_syntax_errors():
+    with pytest.raises(ConfigurationFileInvalidError):
+        Configuration.from_file("./tests/config/invalid_syntax_configuration.yaml")
 
 def test_get_coil():
     configuration = Configuration.from_file(_config_path())
@@ -101,3 +106,19 @@ def test_get_registers():
     )
 
     assert holding_registers == configuration.get_holding_registers()
+
+def test_validate_config_data():
+
+    config = path_to_yaml_data(_config_path())
+
+    for key in ("modbus_settings", "mqtt_settings", "modbus_mapping"):
+        c = config.copy()
+        del c[key]
+        with pytest.raises(ConfigurationFileInvalidError):
+            _validate_config(c)
+
+    for datatype in ("coils", "holding_registers"):
+        c = config.copy()
+        del c["modbus_mapping"][datatype][0]['address']
+        with pytest.raises(ConfigurationFileInvalidError):
+            _validate_config(c)

--- a/tests/config/invalid_syntax_configuration.yaml
+++ b/tests/config/invalid_syntax_configuration.yaml
@@ -1,0 +1,6 @@
+mqtt_settings:
+  host: "mqtt.host"
+  port: 9000
+  command_topic: "commands/#"
+
+- bad yaml

--- a/tests/config/invalid_syntax_configuration.yaml
+++ b/tests/config/invalid_syntax_configuration.yaml
@@ -1,6 +1,0 @@
-mqtt_settings:
-  host: "mqtt.host"
-  port: 9000
-  command_topic: "commands/#"
-
-- bad yaml


### PR DESCRIPTION
## What?

- perform some validation on the specified configuration file to ensure all required attributes are present
- add some tests
- add some details to the README on how to modify config (not 100% across the terminology yet so please make suggestions if anything doesn't sound right)

## Why?

Strict checking of configuration on startup means we need less runtime error handling

## Testing/Proof

I tested each aspect of the validation code manually and have added unit tests to cover most aspects.