### PR TITLE
Use GitHub Action to perform Dockerfile validation

### DIFF
--- a/.github/workflows/docker-validator.yaml
+++ b/.github/workflows/docker-validator.yaml
@@ -2,9 +2,9 @@
 name: Dockerfile and docker-compose Validation
 on:
   push:
-    paths: ['**/Dockerfile', '**/docker-compose.yml']
+    paths: ['Dockerfile', 'docker-compose.yml']
   pull_request:
-    paths: ['**/Dockerfile', '**/docker-compose.yml']
+    paths: ['Dockerfile', 'docker-compose.yml']
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -17,7 +17,9 @@ jobs:
             https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
           chmod +x /usr/local/bin/hadolint
       - name: Run Hadolint
-        run: hadolint --ignore DL3008 **/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: "Dockerfile"
       - name: Install docker-compose-lint
         run: |
           wget -O /usr/local/bin/docker-compose-lint \

--- a/.github/workflows/docker-validator.yaml
+++ b/.github/workflows/docker-validator.yaml
@@ -20,11 +20,5 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: "Dockerfile"
-      - name: Install docker-compose-lint
-        run: |
-          wget -O /usr/local/bin/docker-compose-lint \
-            https://github.com/docker-compose-tools/docker-compose-lint/releases/latest/download/\
-            docker-compose-lint-Linux-x86_64
-          chmod +x /usr/local/bin/docker-compose-lint
-      - name: Run docker-compose-lint
-        run: docker-compose-lint **/docker-compose.yml
+      - name: Check Docker Compose Config
+        run: docker compose -f docker-compose.yaml config -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,15 @@ FROM python:3-slim as python
 ENV PYTHONUNBUFFERED=true
 WORKDIR /app
 
-
 FROM python as poetry
 ENV POETRY_HOME=/opt/poetry
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 ENV PATH="$POETRY_HOME/bin:$PATH"
 ENV CONFIGURATION_PATH="config/configuration.yaml"
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN python -c 'from urllib.request import urlopen; print(urlopen("https://install.python-poetry.org").read().decode())' | python -
 COPY . ./
 RUN poetry install --no-interaction --no-ansi -vvv
-
 
 FROM python as runtime
 ENV PATH="/app/.venv/bin:$PATH"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,6 @@ services:
   mosquitto:
     container_name: mosquitto
     image: eclipse-mosquitto:2.0.14
-    user: ${USER_ID}:${GROUP_ID}
     volumes: [./tests/mosquitto/mosquitto.conf:/mqtt/config/mosquitto.conf]
     ports: [1883:1883, 9001:9001]
     command: [mosquitto, -c, /mqtt/config/mosquitto.conf]


### PR DESCRIPTION
## What?

Use a docker image as github action to run docker validation

## Why?

The current process isn't working very well. After I kicked a new tag, I got the [following error](https://github.com/EvergenEnergy/remote-commands-handler/actions/runs/5195451247/jobs/9368184115):

```
Run hadolint --ignore DL3008 **/Dockerfile
hadolint: **/Dockerfile: withBinaryFile: does not exist (No such file or directory)
Error: Process completed with exit code 1.
```

## Testing/Proof

I run the equivalent action locally: 
```
remote-commands-handler git:(add-inital-integration-tests) ✗ docker run --rm -i hadolint/hadolint < Dockerfile
-:11 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
(venv) ➜  remote-commands-handler git:(add-inital-integration-tests) ✗ docker run --rm -i hadolint/hadolint < Dockerfile
(venv) ➜  remote-commands-handler git:(add-inital-integration-tests) ✗
```