### PR TITLE
UTIL-559: improve coverage

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -13,5 +13,12 @@ class ConfigurationFileNotFoundError(Exception):
 class ConfigurationFileInvalidError(Exception):
     """Exception raised when the configuration file contains errors."""
 
-    def __init__(self, message="Configuration file contains errors: "):
+    def __init__(self, message="Configuration file contains errors"):
+        super().__init__(message)
+
+
+class InvalidArgumentError(Exception):
+    """Exception raised when a function is called with invalid arguments."""
+
+    def __init__(self, message="Unknown argument"):
         super().__init__(message)

--- a/app/memory_order.py
+++ b/app/memory_order.py
@@ -13,12 +13,6 @@ class MemoryOrder:
         return self._order
 
     def _str_to_endian(self, order_string: str):
-        word_order = Endian.Big
-        byte_order = Endian.Big
-
-        if order_string is None:
-            return (byte_order, word_order)
-
         match order_string:  # noqa
             case "AB":
                 word_order = Endian.Big
@@ -32,5 +26,8 @@ class MemoryOrder:
             case "BADC":
                 word_order = Endian.Big
                 byte_order = Endian.Little
+            case _:
+                word_order = Endian.Big
+                byte_order = Endian.Big
 
         return (byte_order, word_order)

--- a/app/memory_order.py
+++ b/app/memory_order.py
@@ -1,4 +1,5 @@
 from pymodbus.constants import Endian
+from app.exceptions import InvalidArgumentError
 
 
 class MemoryOrder:
@@ -17,6 +18,9 @@ class MemoryOrder:
             case "AB":
                 word_order = Endian.Big
                 byte_order = Endian.Big
+            case "ABCD":
+                word_order = Endian.Big
+                byte_order = Endian.Big
             case "BA":
                 word_order = Endian.Little
                 byte_order = Endian.Little
@@ -27,7 +31,8 @@ class MemoryOrder:
                 word_order = Endian.Big
                 byte_order = Endian.Little
             case _:
-                word_order = Endian.Big
-                byte_order = Endian.Big
+                raise InvalidArgumentError(
+                    "Invalid memory order. Valid orders are 'AB', 'BA', 'ABCD', 'CDAB' and 'BADC'."
+                )
 
         return (byte_order, word_order)

--- a/tests/app/test_modbus_client.py
+++ b/tests/app/test_modbus_client.py
@@ -1,6 +1,5 @@
 """Unit tests for the ModbusClient class in the app.modbus_client module."""
 
-import unittest
 import socket
 import threading
 from multiprocessing import Pipe
@@ -18,8 +17,8 @@ from app.configuration import (
 )
 
 
-class TestModbusClient(unittest.TestCase):
-    def setUp(self):
+class TestModbusClient:
+    def setup_class(self):
         # This method will be called before every test
         self.coils = [Coil("test_coil", [1])]
         self.holding_registers = [
@@ -80,7 +79,7 @@ class TestModbusClient(unittest.TestCase):
         client.write_coil("test_coil", True)
         sent = read.recv()
         thread.join()
-        self.assertTrue(sent)
+        assert sent is True
 
     def test_write_coils(self):
         read, write = Pipe(duplex=False)
@@ -97,7 +96,7 @@ class TestModbusClient(unittest.TestCase):
         client.write_coils("test_coil", [True, True])
         sent = read.recv()
         thread.join()
-        self.assertTrue(sent)
+        assert sent is True
 
     def test_write_int_to_holding_registers(self):
         read, write = Pipe(duplex=False)
@@ -114,7 +113,7 @@ class TestModbusClient(unittest.TestCase):
         client.write_register("test_register", 10)
         sent = read.recv()
         thread.join()
-        self.assertTrue(sent)
+        assert sent is True
 
     def test_write_float_to_holding_registers(self):
         read, write = Pipe(duplex=False)
@@ -132,8 +131,4 @@ class TestModbusClient(unittest.TestCase):
         client.write_register("float_register", 32.3)
         sent = read.recv()
         thread.join()
-        self.assertTrue(sent)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert sent is True

--- a/tests/app/test_mqtt_client.py
+++ b/tests/app/test_mqtt_client.py
@@ -1,13 +1,12 @@
 """Unit tests for the MqttClient class in the app.mqtt_client module."""
 
-import unittest
 from unittest.mock import MagicMock
 import paho.mqtt.client as mqtt
 from app.mqtt_client import MqttClient
 
 
-class TestMqttClient(unittest.TestCase):
-    def setUp(self):
+class TestMqttClient:
+    def setup_class(self):
         self.mock_mqtt_client = MagicMock(spec=mqtt.Client)
         self.mqtt_client = MqttClient(
             port=1883, host="localhost", client=self.mock_mqtt_client
@@ -22,7 +21,3 @@ class TestMqttClient(unittest.TestCase):
 
         # Verify that connect was called with the correct parameters
         self.mock_mqtt_client.connect.assert_called_with("localhost", 1883)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/config/test_configuration.py
+++ b/tests/config/test_configuration.py
@@ -24,9 +24,10 @@ def test_throws_exception_when_configuration_file_not_found():
 def test_throws_exception_when_configuration_file_has_syntax_errors():
     bad_yaml_path = "/tmp/bad.yaml"
     with open(bad_yaml_path, "w") as bad:
-        bad.write("not actually yaml")
-    with pytest.raises(ConfigurationFileInvalidError):
+        bad.write("not:\nvalid")
+    with pytest.raises(ConfigurationFileInvalidError) as ex:
         Configuration.from_file(bad_yaml_path)
+    assert "Error encountered parsing YAML" in str(ex.value)
     os.remove(bad_yaml_path)
 
 
@@ -120,11 +121,13 @@ def test_validate_config_data():
     for key in ("modbus_settings", "mqtt_settings", "modbus_mapping"):
         c = config.copy()
         del c[key]
-        with pytest.raises(ConfigurationFileInvalidError):
+        with pytest.raises(ConfigurationFileInvalidError) as ex:
             _validate_config(c)
+        assert key in str(ex.value)
 
     for datatype in ("coils", "holding_registers"):
         c = config.copy()
         del c["modbus_mapping"][datatype][0]["address"]
-        with pytest.raises(ConfigurationFileInvalidError):
+        with pytest.raises(ConfigurationFileInvalidError) as ex:
             _validate_config(c)
+        assert "address" in str(ex.value)

--- a/tests/config/test_memory_order.py
+++ b/tests/config/test_memory_order.py
@@ -48,3 +48,12 @@ def test_get_BADC():
 
     assert word_order == Endian.Big
     assert byte_order == Endian.Little
+
+
+def test_get_default_order():
+    order = MemoryOrder("")
+
+    byte_order, word_order = order.order()
+
+    assert word_order == Endian.Big
+    assert byte_order == Endian.Big

--- a/tests/config/test_memory_order.py
+++ b/tests/config/test_memory_order.py
@@ -1,8 +1,10 @@
 """Tests for the MemoryOrder class."""
 
+import pytest
 from pymodbus.constants import Endian
 
 from app.memory_order import MemoryOrder
+from app.exceptions import InvalidArgumentError
 
 
 def test_get_AB_order():
@@ -50,10 +52,7 @@ def test_get_BADC():
     assert byte_order == Endian.Little
 
 
-def test_get_default_order():
-    order = MemoryOrder("")
-
-    byte_order, word_order = order.order()
-
-    assert word_order == Endian.Big
-    assert byte_order == Endian.Big
+def test_get_unknown_order():
+    with pytest.raises(InvalidArgumentError) as ex:
+        _ = MemoryOrder("FOO")
+    assert "Invalid memory order" in str(ex.value)


### PR DESCRIPTION
## What?

* switch from unittest to pytest style in a couple of tests (we still reference the mock lib as unittest.mock)
* some small changes to increase coverage in configuration.py and memory_order.py

## Why?

Consistency and better coverage. The tests for modbus_client and mqtt_client are still WIP

## Testing/Proof

CI is happy so far