### PR TITLE
UTIL-559: use simpler mock for testing modbus

### DIFF
--- a/tests/app/test_modbus_client.py
+++ b/tests/app/test_modbus_client.py
@@ -1,10 +1,10 @@
-"""Unit tests for the MqttClient class in the app.mqtt_client module."""
+"""Unit tests for the ModbusClient class in the app.modbus_client module."""
 
 from unittest.mock import MagicMock
 from pymodbus.client import ModbusTcpClient
+from app.memory_order import MemoryOrder
 from app.modbus_client import ModbusClient
 from app.configuration import Coil, Configuration, ModbusSettings, HoldingRegister
-from app.memory_order import MemoryOrder
 import pytest
 
 


### PR DESCRIPTION
## What?

Simplify the modbus client test to use a mock for the internal Modbus client

## Why?

Faster and less flaky. There is less need for TCP testing in unit tests now that we have an E2E test

## Testing/Proof

CI