### PR TITLE
Increase coverage on MQTT test

### DIFF
--- a/tests/app/test_mqtt_client.py
+++ b/tests/app/test_mqtt_client.py
@@ -1,8 +1,11 @@
 """Unit tests for the MqttClient class in the app.mqtt_client module."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 import paho.mqtt.client as mqtt
+from paho.mqtt.client import MQTTMessage
 from app.mqtt_client import MqttClient
+import pytest
+import json
 
 
 class TestMqttClient:
@@ -13,11 +16,63 @@ class TestMqttClient:
         )
 
     def test_run(self):
+        topic_list = ["foo", "baa"]
+        self.mqtt_client.subscribe_topics(topic_list)
+
+        mock_modbus = Mock()
+        self.mqtt_client.add_message_callback(mock_modbus.message_callback)
+
+        def call_on_connect(*args):
+            callback = self.mqtt_client._on_connect()
+            callback(self.mock_mqtt_client, None, None, 0)
+
         # Assume connect method always successful
         self.mock_mqtt_client.connect.return_value = 0
+        self.mock_mqtt_client.connect.side_effect = call_on_connect
 
         # Run the method
         self.mqtt_client.run()
 
         # Verify that connect was called with the correct parameters
         self.mock_mqtt_client.connect.assert_called_with("localhost", 1883)
+        # and it called the callback which subscribed to our topics
+        self.mock_mqtt_client.subscribe.call_count == len(topic_list)
+
+        # Pretend that the MQTT broker received a message and our callback is called
+        json_str = json.dumps({"action": "test_coil", "value": True})
+        paho_msg = MQTTMessage()
+        paho_msg.payload = json_str.encode()
+        self.mock_mqtt_client.on_message(self.mock_mqtt_client, None, paho_msg)
+        mock_modbus.message_callback.assert_called_with(json_str)
+
+    def test_bad_message(self, caplog):
+        def read_json(json_str):
+            json.loads(json_str)
+
+        self.mqtt_client.add_message_callback(read_json)
+        self.mqtt_client.run()
+
+        bad_json_str = "{'invalid', 'json'}"
+        paho_msg = MQTTMessage()
+        paho_msg.payload = bad_json_str.encode()
+        self.mock_mqtt_client.on_message(self.mock_mqtt_client, None, paho_msg)
+        msg_str = str(caplog.records[0].message)
+        assert msg_str == f"Error on decoding message: {bad_json_str}"
+
+        self.mqtt_client.stop()
+
+    def test_fail_connect(self):
+        self.mock_mqtt_client.connect.side_effect = OSError("could not connect")
+        with pytest.raises(OSError) as ex:
+            self.mqtt_client.run()
+        assert "Cannot assign requested" in str(ex.value)
+
+    def test_fail_connect_rc(self, caplog):
+        def call_on_connect(*args):
+            callback = self.mqtt_client._on_connect()
+            callback(self.mock_mqtt_client, None, None, 1)
+            assert str(caplog.records[0].message) == "Connection failed"
+
+        self.mock_mqtt_client.connect.side_effect = call_on_connect
+        self.mqtt_client.run()
+        self.mqtt_client.stop()


### PR DESCRIPTION
## What?

Explicitly call callbacks to get 100% coverage of `mqtt_client.py`.

In a couple of places this is just checking log messages for errors - this will hopefully improve with more error handling

## Why?

More coverage = better

## Testing/Proof

CI