### PR TITLE
Catch type errors in config validation

### DIFF
--- a/app/configuration.py
+++ b/app/configuration.py
@@ -83,13 +83,22 @@ class Configuration:
                 msg = f"Error encountered parsing YAML {str(exc.problem_mark)}"
             raise ConfigurationFileInvalidError(msg)
 
-        _validate_config(yaml_data)
+        try:
+            _validate_config(yaml_data)
 
-        coils = _coils_data_from_yaml_data(yaml_data)
-        holding_registers = _holding_register_from_yaml_data(yaml_data)
-        mqtt_settings = _mqtt_settings_from_yaml_data(yaml_data)
-        modbus_settings = _modbus_settings_from_yaml_data(yaml_data)
-        return cls(coils, holding_registers, mqtt_settings, modbus_settings)
+            coils = _coils_data_from_yaml_data(yaml_data)
+            holding_registers = _holding_register_from_yaml_data(yaml_data)
+            mqtt_settings = _mqtt_settings_from_yaml_data(yaml_data)
+            modbus_settings = _modbus_settings_from_yaml_data(yaml_data)
+            return cls(coils, holding_registers, mqtt_settings, modbus_settings)
+        except TypeError as ex:
+            raise ConfigurationFileInvalidError(
+                f"Error parsing configuration YAML: {ex}"
+            )
+        except KeyError as ex:
+            raise ConfigurationFileInvalidError(
+                f"Error parsing configuration YAML: expected key {ex} was not found"
+            )
 
     def get_coil(self, name: str) -> Coil:
         return self.coils_map[name]

--- a/app/configuration.py
+++ b/app/configuration.py
@@ -162,8 +162,8 @@ def _validate_config(config: dict):
     }
     try:
         for req_key, req_items in required_settings.items():
-            assert (
-                req_key in config
+            assert req_key in config and isinstance(
+                config[req_key], dict
             ), f"No {req_key!r} section provided in configuration"
             for item in req_items:
                 assert (
@@ -189,5 +189,5 @@ def _validate_config(config: dict):
                 assert (
                     key in ref
                 ), f"Holding register reference #{index} has no config setting for {key!r}"
-    except AssertionError as ex:
+    except (AssertionError, TypeError) as ex:
         raise ConfigurationFileInvalidError(ex)

--- a/tests/config/test_configuration.py
+++ b/tests/config/test_configuration.py
@@ -121,6 +121,12 @@ def test_validate_config_data():
 
     for key in ("modbus_settings", "mqtt_settings", "modbus_mapping"):
         c = deepcopy(config)
+
+        c[key] = ["is a list", "not a dict"]
+        with pytest.raises(ConfigurationFileInvalidError) as ex:
+            _validate_config(c)
+        assert key in str(ex.value)
+
         del c[key]
         with pytest.raises(ConfigurationFileInvalidError) as ex:
             _validate_config(c)
@@ -128,11 +134,13 @@ def test_validate_config_data():
 
         if key != "modbus_mapping":
             c = deepcopy(config)
+
             c[key]["host"] = ""
             with pytest.raises(ConfigurationFileInvalidError) as ex:
                 _validate_config(c)
             assert "host" in str(ex.value)
             assert key in str(ex.value)
+
             del c[key]["host"]
             with pytest.raises(ConfigurationFileInvalidError) as ex:
                 _validate_config(c)

--- a/tests/config/test_configuration.py
+++ b/tests/config/test_configuration.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import pytest
 from pymodbus.constants import Endian
 
+import app.configuration
 from app.configuration import (
     Coil,
     Configuration,
@@ -153,3 +154,37 @@ def test_validate_config_data():
         with pytest.raises(ConfigurationFileInvalidError) as ex:
             _validate_config(c)
         assert "address" in str(ex.value)
+
+
+def test_key_error_in_config_parsing(monkeypatch):
+    """
+    Test that if the config module looks for a dict key which isn't set in the file,
+    we capture that error in a custom exception
+    """
+
+    def modbus_settings_with_unknown_key(data):
+        return ModbusSettings(data["not_host_key"], data["not_port"])
+
+    def modbus_settings_with_bad_type(data):
+        settings = [1, 2, 3]
+        return ModbusSettings(settings["host"], settings["port"])
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            app.configuration,
+            "_modbus_settings_from_yaml_data",
+            modbus_settings_with_unknown_key,
+        )
+        with pytest.raises(ConfigurationFileInvalidError) as ex:
+            _ = Configuration.from_file(_config_path())
+        assert "Error parsing configuration" in str(ex.value)
+        assert "not_host_key" in str(ex.value)
+
+        m.setattr(
+            app.configuration,
+            "_modbus_settings_from_yaml_data",
+            modbus_settings_with_bad_type,
+        )
+        with pytest.raises(ConfigurationFileInvalidError) as ex:
+            _ = Configuration.from_file(_config_path())
+        assert "Error parsing configuration" in str(ex.value)


### PR DESCRIPTION
## What?

Additional config validation checks:
- when a section is present but not the expected data type
- any TypeErrors during validation for unanticipated config file weirdness

Also catch TypeError and KeyError when constructing the Configuration object itself - this will catch developer errors where a key is assumed to exist but not checked for in validation.

## Why?

We can't anticipate in advance everything that might be wrong with a config file, so this aims to catch errors more generally. 

We're assuming that when a developer adds a new key to the config file, they must also add a check for it to the validation function. If they don't, the process will fail to start, but it will hopefully fail with a somewhat readable error.

## Testing/Proof

CI but also by manually changing keys within configuration.py after validation, e.g.

`mqtt_settings = data["mqtt_settingsZZ"]`

which gives the error:

```
2023-06-09 11:09:51:INFO:Starting service
2023-06-09 11:09:51:INFO:Error parsing configuration YAML: expected key 'mqtt_settingsZZ' was not found
2023-06-09 11:09:51:ERROR:Error retrieving configuration, exiting
```