### PR TITLE
Add handling for more error scenarios

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -22,3 +22,24 @@ class InvalidArgumentError(Exception):
 
     def __init__(self, message="Unknown argument"):
         super().__init__(message)
+
+
+class InvalidMessageError(Exception):
+    """Exception raised when a message is not in the required format."""
+
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class ModbusClientError(Exception):
+    """Exception raised when we fail to connect to the Modbus server."""
+
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class UnknownCommandError(Exception):
+    """Exception raised when no coil or register is found matching the specified message action."""
+
+    def __init__(self, action):
+        super().__init__(f"No coil or register found to match {action!r}")

--- a/app/message.py
+++ b/app/message.py
@@ -1,0 +1,28 @@
+"""Message decoding and validation module.
+
+This module encapsulates the functionality required to read and validate an incoming MQTT message.
+"""
+
+from app.exceptions import InvalidMessageError
+import json
+from json import JSONDecodeError
+
+
+class CommandMessage:
+    """Read message contents and validate its structure."""
+
+    @classmethod
+    def read(cls, message_str: str):
+        try:
+            message_obj = json.loads(message_str)
+            assert message_obj.get("action")
+            assert "value" in message_obj
+            return message_obj
+        except JSONDecodeError as ex:
+            raise InvalidMessageError(f"Message is invalid JSON syntax: {ex}")
+        except AssertionError:
+            raise InvalidMessageError(
+                "Message is missing required components 'action' and/or 'value'"
+            )
+        except Exception as ex:
+            raise InvalidMessageError(f"Invalid message: {ex}")

--- a/tests/app/test_message.py
+++ b/tests/app/test_message.py
@@ -1,0 +1,52 @@
+"""Tests for the CommandMessage module."""
+
+import pytest
+import json
+from app.message import CommandMessage
+from app.exceptions import InvalidMessageError
+
+
+def test_good_message():
+    json_obj = {"action": "somecoil", "value": True}
+    json_str = json.dumps(json_obj)
+    read_msg = CommandMessage.read(json_str)
+    assert "action" in read_msg
+    assert "value" in read_msg
+
+
+def test_bad_message_structure():
+    json_obj = {"action": "somecoil", "value": True}
+    for key in ("action", "value"):
+        json_obj["foo"] = json_obj[key]
+        del json_obj[key]
+        json_str = json.dumps(json_obj)
+        print(json_str)
+        with pytest.raises(InvalidMessageError) as ex:
+            _ = CommandMessage.read(json_str)
+        assert "Message is missing required components" in str(ex.value)
+        assert ex.type == InvalidMessageError
+        json_obj[key] = json_obj["foo"]
+
+
+def test_bad_message_syntax():
+    json_str = "not a real json string"
+    with pytest.raises(InvalidMessageError) as ex:
+        _ = CommandMessage.read(json_str)
+    assert "Message is invalid JSON syntax" in str(ex.value)
+    assert ex.type == InvalidMessageError
+
+
+def test_bad_message_unhandled_exception(monkeypatch):
+    def fake_json_load(_):
+        raise TypeError("unpredictable error")
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            json,
+            "loads",
+            fake_json_load,
+        )
+        with pytest.raises(InvalidMessageError) as ex:
+            _ = CommandMessage.read("")
+        assert "Invalid message" in str(ex.value)
+        assert ex.type == InvalidMessageError

--- a/tests/app/test_mqtt_client.py
+++ b/tests/app/test_mqtt_client.py
@@ -39,11 +39,12 @@ class TestMqttClient:
         self.mock_mqtt_client.subscribe.call_count == len(topic_list)
 
         # Pretend that the MQTT broker received a message and our callback is called
-        json_str = json.dumps({"action": "test_coil", "value": True})
+        json_obj = {"action": "test_coil", "value": True}
+        json_str = json.dumps(json_obj)
         paho_msg = MQTTMessage()
         paho_msg.payload = json_str.encode()
         self.mock_mqtt_client.on_message(self.mock_mqtt_client, None, paho_msg)
-        mock_modbus.message_callback.assert_called_with(json_str)
+        mock_modbus.message_callback.assert_called_with(json_obj)
 
     def test_bad_message(self, caplog):
         def read_json(json_str):
@@ -57,7 +58,7 @@ class TestMqttClient:
         paho_msg.payload = bad_json_str.encode()
         self.mock_mqtt_client.on_message(self.mock_mqtt_client, None, paho_msg)
         msg_str = str(caplog.records[0].message)
-        assert msg_str == f"Error on decoding message: {bad_json_str}"
+        assert "Message is invalid JSON" in msg_str
 
         self.mqtt_client.stop()
 


### PR DESCRIPTION
## What?

Add custom exceptions and logging for error scenarios including:
- incoming message with malformed JSON or missing object keys
- incoming message with an action that doesn't match any known config
- failure to send to to Modbus
- badly formed `command_topic` in config

There is also a change to the callback functions used when messages are received:
- the main process now calls a single callback which looks for matching coils and registers, so that we can raise an error if neither are matched
- parsing and validation of the MQTT message happens in a new module rather than within main.py, and is performed within the MQTT `_on_message` callback

## Why?

We want to catch all possible runtime errors to ensure that they don't kill the main process. An error reporting mechanism is still to be added, but this is preparatory work to anticipate and handle possible error scenarios.

## Testing/Proof

Full test coverage is maintained, plus some manual testing to ensure the main loop persists