### PR TITLE
Configure optional error topic

### DIFF
--- a/app/configuration.py
+++ b/app/configuration.py
@@ -202,7 +202,7 @@ def _validate_config(config: dict):
             ), "The error topic must be a valid MQTT topic name"
 
             assert (
-                error_topic.count("#") == 0
+                error_topic.count("#") + error_topic.count("+") == 0
             ), "The error topic must not contain a wildcard character"
 
         mapping = config["modbus_mapping"]

--- a/app/configuration.py
+++ b/app/configuration.py
@@ -49,6 +49,11 @@ class MqttSettings:
     host: str
     port: int
     command_topic: str
+    error_topic: str = None
+    pub_errors: bool = False
+
+    def __post_init__(self):
+        self.pub_errors = self.error_topic is not None and len(self.error_topic) > 0
 
 
 @dataclass
@@ -132,7 +137,10 @@ def _modbus_settings_from_yaml_data(data) -> ModbusSettings:
 def _mqtt_settings_from_yaml_data(data) -> MqttSettings:
     mqtt_settings = data["mqtt_settings"]
     return MqttSettings(
-        mqtt_settings["host"], mqtt_settings["port"], mqtt_settings["command_topic"]
+        mqtt_settings["host"],
+        mqtt_settings["port"],
+        mqtt_settings["command_topic"],
+        mqtt_settings.get("error_topic"),
     )
 
 
@@ -179,16 +187,23 @@ def _validate_config(config: dict):
                     item in config[req_key] and config[req_key][item]
                 ), f"No {item!r} provided in {req_key!r} section of configuration"
 
-        def _is_valid_command_topic(topic):
+        def _is_valid_mqtt_topic(topic):
             # Command topic must be str, must not have more than 7 levels
-            return (
-                isinstance(config["mqtt_settings"]["command_topic"], str)
-                and config["mqtt_settings"]["command_topic"].count("/") <= 7  # noqa
-            )
+            return isinstance(topic, str) and topic.count("/") <= 7
 
-        assert _is_valid_command_topic(
+        assert _is_valid_mqtt_topic(
             config["mqtt_settings"]["command_topic"]
         ), "The command topic must be a valid MQTT topic name"
+
+        error_topic = config["mqtt_settings"].get("error_topic")
+        if error_topic:
+            assert _is_valid_mqtt_topic(
+                error_topic
+            ), "The error topic must be a valid MQTT topic name"
+
+            assert (
+                error_topic.count("#") == 0
+            ), "The error topic must not contain a wildcard character"
 
         mapping = config["modbus_mapping"]
         keys_defined = sum(

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -2,7 +2,8 @@
 mqtt_settings:
   host: mosquitto
   port: 1883
-  command_topic: commands/#  # The mqtt topic that contains the relevant commands.
+  command_topic: commands/#  # We subscribe to this MQTT topic to receive commands
+  error_topic: error  # If this has a value, we publish error messages under this MQTT topic
 modbus_settings:
   host: pymodbus
   port: 5020

--- a/tests/config/example_configuration.yaml
+++ b/tests/config/example_configuration.yaml
@@ -3,6 +3,7 @@ mqtt_settings:
   host: mqtt.host
   port: 9000
   command_topic: commands/#
+  error_topic: error/
 modbus_settings:
   host: modbus.host
   port: 8080

--- a/tests/config/test_configuration.py
+++ b/tests/config/test_configuration.py
@@ -170,10 +170,11 @@ def test_validate_config_data():
         assert False
 
     error_topic_wildcard = deepcopy(config)
-    error_topic_wildcard["mqtt_settings"]["error_topic"] = "error/#"
-    with pytest.raises(ConfigurationFileInvalidError) as ex:
-        _validate_config(error_topic_wildcard)
-    assert "wildcard" in str(ex.value)
+    for char in ("#", "+"):
+        error_topic_wildcard["mqtt_settings"]["error_topic"] = f"error/{char}/topic"
+        with pytest.raises(ConfigurationFileInvalidError) as ex:
+            _validate_config(error_topic_wildcard)
+        assert "wildcard" in str(ex.value)
 
     for datatype in ("coils", "holding_registers"):
         c = deepcopy(config)

--- a/tests/config/test_configuration.py
+++ b/tests/config/test_configuration.py
@@ -14,6 +14,7 @@ from app.configuration import (
     MqttSettings,
     path_to_yaml_data,
     _validate_config,
+    _mqtt_settings_from_yaml_data,
 )
 from app.exceptions import ConfigurationFileNotFoundError, ConfigurationFileInvalidError
 
@@ -82,6 +83,19 @@ def test_able_to_get_mqtt_settings():
     assert mqtt_settings.port == 9000
     assert mqtt_settings.host == "mqtt.host"
     assert mqtt_settings.command_topic == "commands/#"
+    assert mqtt_settings.pub_errors is True
+
+    config = path_to_yaml_data(_config_path())
+
+    no_err_topic = deepcopy(config)
+    del no_err_topic["mqtt_settings"]["error_topic"]
+    new_mqtt_settings = _mqtt_settings_from_yaml_data(no_err_topic)
+    assert new_mqtt_settings.pub_errors is False
+
+    empty_err_topic = deepcopy(config)
+    empty_err_topic["mqtt_settings"]["error_topic"] = ""
+    new_mqtt_settings = _mqtt_settings_from_yaml_data(empty_err_topic)
+    assert new_mqtt_settings.pub_errors is False
 
 
 def test_able_to_get_modbus_settings():
@@ -147,6 +161,19 @@ def test_validate_config_data():
                 _validate_config(c)
             assert "host" in str(ex.value)
             assert key in str(ex.value)
+
+    without_error_topic = deepcopy(config)
+    del without_error_topic["mqtt_settings"]["error_topic"]
+    try:
+        _validate_config(without_error_topic)
+    except Exception:
+        assert False
+
+    error_topic_wildcard = deepcopy(config)
+    error_topic_wildcard["mqtt_settings"]["error_topic"] = "error/#"
+    with pytest.raises(ConfigurationFileInvalidError) as ex:
+        _validate_config(error_topic_wildcard)
+    assert "wildcard" in str(ex.value)
 
     for datatype in ("coils", "holding_registers"):
         c = deepcopy(config)


### PR DESCRIPTION
## What?

* Accept an optional config setting specifying an MQTT topic to publish errors to
* Set a bool value to true if topic is supplied and of non-zero length
* Check that it's a valid topic names and doesn't contain wildcard chars (because it's for publishing not subscribing)

## Why?

This will enable the service to send error messages when the topic is configured

## Testing/Proof

Automated tests check that config file validation is successful with or without the error_topic