### PR TITLE
Use environment variables in config settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ You will need to modify the `configuration.yaml` file to match your MQTT and Mod
 - The `modbus_mappings` section allows you to configure the coils and holding registers available on your Modbus server
 - Each entry under `coils` and `holding_registers` refers to a space where Modbus will store data. The `name` for each entry will correspond to the `action` of your JSON payloads. The `address` for each entry identifies the relevant location within the Modbus server.
 - For holding registers, you must also specify the `data_type` and `byte_order` for each register.
+- The settings `site_name` and `serial_number` may be populated from environment variables of the same name, as follows:
+```
+site_settings:
+  site_name: $SITE_NAME
+  serial_number: $SERIAL_NUMBER
+```
 
 ## Contributing
 

--- a/app/configuration.py
+++ b/app/configuration.py
@@ -91,7 +91,7 @@ class Configuration:
 
         try:
             yaml_data = path_to_yaml_data(path)
-            yaml_data["site_settings"] = interpolate_environment_vars(
+            yaml_data["site_settings"] = _interpolate_environment_vars(
                 yaml_data["site_settings"]
             )
         except yaml.YAMLError as exc:
@@ -151,7 +151,7 @@ def path_to_yaml_data(path: str):
         return yaml.safe_load(file)
 
 
-def interpolate_environment_vars(data: dict):
+def _interpolate_environment_vars(data: dict):
     interpolated = {}
     for key, value in data.items():
         var_name = value

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,7 +1,7 @@
 ---
 site_settings:
   site_name: localsite
-  serial_number: DEV123
+  serial_number: SERIAL_123
 mqtt_settings:
   host: mosquitto
   port: 1883

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -1,4 +1,7 @@
 ---
+site_settings:
+  site_name: localsite
+  serial_number: DEV123
 mqtt_settings:
   host: mosquitto
   port: 1883

--- a/main.py
+++ b/main.py
@@ -106,7 +106,7 @@ def get_configuration_with_overrides(args):
 
 
 def setup_error_handler(configuration: Configuration) -> ErrorHandler:
-    return ErrorHandler.from_config(configuration, mqtt.Client())
+    return ErrorHandler(configuration, mqtt.Client())
 
 
 def setup_modbus_client(

--- a/main.py
+++ b/main.py
@@ -101,13 +101,12 @@ def get_configuration_with_overrides(args):
         configuration.get_holding_registers(),
         mqtt_settings_with_override,
         modbus_settings_with_override,
+        configuration.get_site_settings(),
     )
 
 
-def setup_error_handler(
-    configuration: Configuration, mqtt_client: mqtt.Client
-) -> ErrorHandler:
-    return ErrorHandler.from_config(configuration, mqtt_client)
+def setup_error_handler(configuration: Configuration) -> ErrorHandler:
+    return ErrorHandler.from_config(configuration, mqtt.Client())
 
 
 def setup_modbus_client(
@@ -124,13 +123,13 @@ def setup_modbus_client(
 
 
 def setup_mqtt_client(
-    configuration: Configuration, mqtt_client: mqtt.Client, error_handler: ErrorHandler
+    configuration: Configuration, error_handler: ErrorHandler
 ) -> MqttReader:
     return MqttReader(
         configuration.get_mqtt_settings().host,
         configuration.get_mqtt_settings().port,
         [configuration.mqtt_settings.command_topic],
-        mqtt_client,
+        mqtt.Client(),
         error_handler,
     )
 
@@ -142,7 +141,6 @@ def main():
         format="%(asctime)s:%(levelname)s:%(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
-    logging.info("Starting service")
     args = handle_args()
 
     try:
@@ -152,9 +150,13 @@ def main():
         logging.error("Error retrieving configuration, exiting")
         sys.exit(1)
 
-    error_handler = setup_error_handler(configuration, mqtt.Client())
+    logging.info(
+        f"Starting service at {configuration.get_site_settings().site_name}"
+        f"/{configuration.get_site_settings().serial_number}"
+    )
+    error_handler = setup_error_handler(configuration)
     modbus_client = setup_modbus_client(configuration, error_handler)
-    mqtt_reader = setup_mqtt_client(configuration, mqtt.Client(), error_handler)
+    mqtt_reader = setup_mqtt_client(configuration, error_handler)
 
     def write_to_modbus(message):
         try:

--- a/tests/app/test_error_handler.py
+++ b/tests/app/test_error_handler.py
@@ -1,8 +1,6 @@
 from app.error_handler import ErrorHandler
-from app.exceptions import InvalidArgumentError
 from app.configuration import Configuration, _mqtt_settings_from_yaml_data
 import paho.mqtt.client as mqtt
-import pytest
 from unittest.mock import MagicMock
 
 
@@ -14,11 +12,12 @@ def example_config_path():
 def test_create_error_handler():
     mock_mqtt_client = MagicMock(spec=mqtt.Client)
     config = Configuration.from_file(example_config_path())
-    error = ErrorHandler.from_config(config, mock_mqtt_client)
+    error = ErrorHandler(config, mock_mqtt_client)
     assert error.active is True
 
 
 def test_no_error_handler():
+    mock_mqtt_client = MagicMock(spec=mqtt.Client)
     config = Configuration.from_file(example_config_path())
     config.mqtt_settings = _mqtt_settings_from_yaml_data(
         {
@@ -30,20 +29,13 @@ def test_no_error_handler():
             }
         }
     )
-    error = ErrorHandler.from_config(config)
+    error = ErrorHandler(config, mock_mqtt_client)
     assert error.active is False
     error.publish(error.Category.UNKNOWN_COMMAND, "foo")
-
-
-def test_partial_init():
-    config = Configuration.from_file(example_config_path())
-    with pytest.raises(InvalidArgumentError) as ex:
-        _ = ErrorHandler.from_config(config)
-    assert "requires MQTT settings and client" in str(ex)
 
 
 def test_publish_error():
     mock_mqtt_client = MagicMock(spec=mqtt.Client)
     config = Configuration.from_file(example_config_path())
-    error = ErrorHandler.from_config(config, mock_mqtt_client)
+    error = ErrorHandler(config, mock_mqtt_client)
     error.publish(error.Category.UNKNOWN_COMMAND, "oops")

--- a/tests/app/test_modbus_client.py
+++ b/tests/app/test_modbus_client.py
@@ -6,7 +6,13 @@ from pymodbus.exceptions import ModbusException
 from app.memory_order import MemoryOrder
 from app.modbus_client import ModbusClient
 from app.payload_builder import PayloadBuilder
-from app.configuration import Coil, Configuration, ModbusSettings, HoldingRegister
+from app.configuration import (
+    Coil,
+    Configuration,
+    ModbusSettings,
+    HoldingRegister,
+    SiteSettings,
+)
 from app.error_handler import ErrorHandler
 from app.exceptions import ModbusClientError, InvalidMessageError
 import pytest
@@ -21,12 +27,17 @@ class TestModbusClient:
                 "float_register", MemoryOrder("BA"), "FLOAT32-IEEE", 1.0, [1]
             ),
         ]
+        self.site_settings = SiteSettings("localhost", "DEV123")
         self.modbus_settings = ModbusSettings("localhost", 5020)
         self.mock_client = MagicMock(spec=ModbusTcpClient)
         self.mock_error_handler = MagicMock(spec=ErrorHandler)
 
         configuration = Configuration(
-            self.coils, self.holding_registers, {}, self.modbus_settings
+            self.coils,
+            self.holding_registers,
+            {},
+            self.modbus_settings,
+            self.site_settings,
         )
 
         self.modbus_client = ModbusClient(

--- a/tests/app/test_mqtt_reader.py
+++ b/tests/app/test_mqtt_reader.py
@@ -49,7 +49,7 @@ class TestMqttReader:
         self.mock_mqtt_client.on_message(self.mock_mqtt_client, None, paho_msg)
         mock_modbus.message_callback.assert_called_with(json_obj)
 
-    def test_bad_message(self, caplog):
+    def test_bad_message(self):
         def read_json(json_str):
             json.loads(json_str)
 
@@ -60,8 +60,6 @@ class TestMqttReader:
         paho_msg = MQTTMessage()
         paho_msg.payload = bad_json_str.encode()
         self.mock_mqtt_client.on_message(self.mock_mqtt_client, None, paho_msg)
-        msg_str = str(caplog.records[0].message)
-        assert "Message is invalid JSON" in msg_str
         self.mock_error_handler.publish.assert_called()
 
         self.mqtt_reader.stop()
@@ -72,11 +70,10 @@ class TestMqttReader:
             self.mqtt_reader.run()
         assert "Cannot connect to MQTT broker" in str(ex.value)
 
-    def test_fail_connect_rc(self, caplog):
+    def test_fail_connect_rc(self):
         def call_on_connect(*args):
             callback = self.mqtt_reader._on_connect()
             callback(self.mock_mqtt_client, None, None, 1)
-            assert str(caplog.records[0].message) == "Connection failed"
             self.mock_error_handler.publish.assert_called()
 
         self.mock_mqtt_client.connect.side_effect = call_on_connect

--- a/tests/app/test_mqtt_reader.py
+++ b/tests/app/test_mqtt_reader.py
@@ -82,3 +82,11 @@ class TestMqttReader:
         self.mock_mqtt_client.connect.side_effect = call_on_connect
         self.mqtt_reader.run()
         self.mqtt_reader.stop()
+        self.mock_mqtt_client.connect.side_effect = None
+
+    def test_disconnect(self, caplog):
+        self.mock_mqtt_client.connect.return_value = 0
+        self.mqtt_reader.run()
+        callback = self.mock_mqtt_client.on_disconnect
+        callback(self.mock_mqtt_client, None, 1)
+        assert "MQTT client has disconnected: 1" == str(caplog.records[0].message)

--- a/tests/config/bad_env_var_configuration.yaml
+++ b/tests/config/bad_env_var_configuration.yaml
@@ -1,0 +1,16 @@
+---
+site_settings:
+  site_name: $NOT_SITE_NAME
+  serial_number: $SERIAL_NUMBER
+mqtt_settings:
+  host: mqtt.host
+  port: 9000
+  command_topic: commands/#
+  error_topic: error/
+modbus_settings:
+  host: modbus.host
+  port: 8080
+modbus_mapping:
+  coils:
+    - name: evgBatteryModeCoil
+      address: [3]

--- a/tests/config/example_configuration.yaml
+++ b/tests/config/example_configuration.yaml
@@ -1,4 +1,7 @@
 ---
+site_settings:
+  site_name: testsite
+  serial_number: testserial
 mqtt_settings:
   host: mqtt.host
   port: 9000

--- a/tests/config/good_env_var_configuration.yaml
+++ b/tests/config/good_env_var_configuration.yaml
@@ -1,0 +1,16 @@
+---
+site_settings:
+  site_name: $SITE_NAME
+  serial_number: $SERIAL_NUMBER
+mqtt_settings:
+  host: mqtt.host
+  port: 9000
+  command_topic: commands/#
+  error_topic: error/
+modbus_settings:
+  host: modbus.host
+  port: 8080
+modbus_mapping:
+  coils:
+    - name: evgBatteryModeCoil
+      address: [3]

--- a/tests/config/test_configuration.py
+++ b/tests/config/test_configuration.py
@@ -12,6 +12,7 @@ from app.configuration import (
     HoldingRegister,
     ModbusSettings,
     MqttSettings,
+    SiteSettings,
     path_to_yaml_data,
     _validate_config,
     _mqtt_settings_from_yaml_data,
@@ -107,13 +108,23 @@ def test_able_to_get_modbus_settings():
     assert modbus_settings.host == "modbus.host"
 
 
+def test_able_to_get_site():
+    configuration = Configuration.from_file(_config_path())
+
+    site_settings = configuration.get_site_settings()
+
+    assert site_settings.site_name == "testsite"
+    assert site_settings.serial_number == "testserial"
+
+
 def test_get_coils():
     coils = [Coil("test_coil", 1)]
     holding_registers = []
     mqtt_settings = MqttSettings("test", 100, "test")
     modbus_settings = ModbusSettings("localhost", 10)
+    site_settings = SiteSettings("testsite", "testdevice")
     configuration = Configuration(
-        coils, holding_registers, mqtt_settings, modbus_settings
+        coils, holding_registers, mqtt_settings, modbus_settings, site_settings
     )
 
     assert coils == configuration.get_coils()
@@ -124,8 +135,9 @@ def test_get_registers():
     holding_registers = [HoldingRegister("test", "AB", "STR", 1.0, [0])]
     mqtt_settings = MqttSettings("test", 100, "test")
     modbus_settings = ModbusSettings("localhost", 10)
+    site_settings = SiteSettings("testsite", "testdevice")
     configuration = Configuration(
-        coils, holding_registers, mqtt_settings, modbus_settings
+        coils, holding_registers, mqtt_settings, modbus_settings, site_settings
     )
 
     assert holding_registers == configuration.get_holding_registers()

--- a/tests/config/test_configuration.py
+++ b/tests/config/test_configuration.py
@@ -20,6 +20,12 @@ from app.configuration import (
 from app.exceptions import ConfigurationFileNotFoundError, ConfigurationFileInvalidError
 
 
+def _config_path():
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    config_path = os.path.join(current_dir, "example_configuration.yaml")
+    return config_path
+
+
 def test_throws_exception_when_configuration_file_not_found():
     with pytest.raises(ConfigurationFileNotFoundError):
         Configuration.from_file("./tests/config/bad-example_configuration.yaml")
@@ -43,12 +49,6 @@ def test_get_coil():
 
     assert evg_battery_mode_coil_address.address == [3]
     assert target_watt_coil.address == [4]
-
-
-def _config_path():
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    config_path = os.path.join(current_dir, "example_configuration.yaml")
-    return config_path
 
 
 def test_get_holding_registers():
@@ -228,3 +228,27 @@ def test_key_error_in_config_parsing(monkeypatch):
         with pytest.raises(ConfigurationFileInvalidError) as ex:
             _ = Configuration.from_file(_config_path())
         assert "Error parsing configuration" in str(ex.value)
+
+
+def test_read_settings_from_env():
+    env_var_path = _config_path().replace("example", "good_env_var")
+    with pytest.raises(ConfigurationFileInvalidError) as ex:
+        _ = Configuration.from_file(env_var_path)
+    assert "Missing value for expected environment variable 'SITE_NAME'" == str(
+        ex.value
+    )
+
+    os.environ["SITE_NAME"] = "site-from-env"
+    os.environ["SERIAL_NUMBER"] = "serial-from-env"
+    config = Configuration.from_file(env_var_path)
+    assert config.get_site_settings().site_name == "site-from-env"
+    assert config.get_site_settings().serial_number == "serial-from-env"
+    os.environ["SITE_NAME"] = ""
+    os.environ["SERIAL_NUMBER"] = ""
+
+
+def test_read_bad_settings_from_env():
+    env_var_path = _config_path().replace("example", "bad_env_var")
+    with pytest.raises(ConfigurationFileInvalidError) as ex:
+        _ = Configuration.from_file(env_var_path)
+    assert "looks like an environment variable but has an invalid name" in str(ex.value)

--- a/tests/end-to-end/configuration.yaml
+++ b/tests/end-to-end/configuration.yaml
@@ -1,4 +1,7 @@
 ---
+site_settings:
+  site_name: e2esite
+  serial_number: E2ETEST
 mqtt_settings:
   host: mosquitto
   port: 1883

--- a/tests/end-to-end/configuration.yaml
+++ b/tests/end-to-end/configuration.yaml
@@ -3,6 +3,7 @@ mqtt_settings:
   host: mosquitto
   port: 1883
   command_topic: commands/#
+  error_topic: error
 modbus_settings:
   host: pymodbus
   port: 5020

--- a/tests/end-to-end/test_able_to_sent_to_commands.py
+++ b/tests/end-to-end/test_able_to_sent_to_commands.py
@@ -1,3 +1,4 @@
+import os
 import time
 import json
 import random
@@ -48,9 +49,9 @@ def test_able_to_send_integer16(
     mqtt_client: mqtt.Client, modbus_client: ModbusTcpClient
 ):
     random_value = random.randint(0, 30)
-    message_dictorionary = {"action": "testRegister", "value": random_value}
+    message_dictionary = {"action": "testRegister", "value": random_value}
 
-    message = json.dumps(message_dictorionary)
+    message = json.dumps(message_dictionary)
 
     mqtt_client.publish("commands/test", message)
 
@@ -107,9 +108,9 @@ def test_able_to_send_integer64(
     mqtt_client: mqtt.Client, modbus_client: ModbusTcpClient
 ):
     random_value = random.randint(0, 100)
-    message_dictorionary = {"action": "testInt64Register", "value": random_value}
+    message_dictionary = {"action": "testInt64Register", "value": random_value}
 
-    message = json.dumps(message_dictorionary)
+    message = json.dumps(message_dictionary)
 
     mqtt_client.publish("commands/test", message)
 
@@ -127,9 +128,9 @@ def test_able_to_send_integer64(
 @pytest.mark.end_to_end
 def test_able_to_send_uint64(mqtt_client: mqtt.Client, modbus_client: ModbusTcpClient):
     random_value = random.randint(0, 100)
-    message_dictorionary = {"action": "testUInt64Register", "value": random_value}
+    message_dictionary = {"action": "testUInt64Register", "value": random_value}
 
-    message = json.dumps(message_dictorionary)
+    message = json.dumps(message_dictionary)
 
     mqtt_client.publish("commands/test", message)
 
@@ -142,3 +143,44 @@ def test_able_to_send_uint64(mqtt_client: mqtt.Client, modbus_client: ModbusTcpC
     )
 
     assert decoder.decode_64bit_uint() == random_value
+
+
+@pytest.mark.end_to_end
+def test_read_error_messages(mqtt_client: mqtt.Client):
+    # Subscribe to the error topic and write messages to file
+    msg_log = "/tmp/message_log"
+    if os.path.exists(msg_log):
+        os.remove(msg_log)
+
+    def read_error(_client, _userdata, message):
+        # When we get an error message from MQTT, write it to file
+        msg_str = message.payload.decode()
+        msg_obj = json.loads(msg_str)
+        with open(msg_log, "a") as err:
+            err.write(f"{msg_str}\n")
+        return msg_obj
+
+    mqtt_client.subscribe("error/#")
+    mqtt_client.on_message = read_error
+
+    # Generate two error messages by sending bad commands
+    def send_bad_command(msg_obj):
+        message = json.dumps(msg_obj)
+        mqtt_client.publish("commands/test", message)
+
+    send_bad_command({"invalid": ["message", "structure"]})
+    send_bad_command({"action": "NotARealCoil", "value": 0})
+
+    # Run the client loop to allow the callback to be executed
+    mqtt_client.loop_start()
+    time.sleep(1)
+    mqtt_client.loop_stop()
+
+    # Check the file for error messages
+    with open(msg_log) as err_in:
+        line1 = err_in.readline()
+        line2 = err_in.readline()
+    assert "InvalidMessage" in line1
+    assert "UnknownCommand" in line2
+
+    os.remove(msg_log)


### PR DESCRIPTION
## What?

- Add a `site_settings` section to config containing `site_name` and `serial_number`
- These values can be defined in the file or will be read from the environment if the values are `$SITE_NAME`/`$SERIAL_NUMBER`
- Fail the config read if the site setting values look like env vars but don't match those names, or if the specified env vars are empty
- Log the values on startup and use them in the MQTT topic when publishing error messages
- Simplify ErrorHandler construction and set those values as attributes
- Add a callback for disconnection from the MQTT broker so we log an error if we unexpectedly lose contact
- Add an E2E tests which verifies that error messages are sent, and that commands will still be received afterwards

## Why?

We will need site/serial to distinguish error messages from different systems, and it would be convenient to be able to use a single config files across multiple devices yet set separate serial numbers via the environment.

## Testing/Proof

The `test_configuration.py` test shows the three test cases:
- interpolation of correctly specified env vars
- failure to start if an env var is correctly specified but empty
- failure to start if an env var is incorrectly specified (starts with `$` but doesn't match the key name)

which are also demonstrated here:

![Screen Shot 2023-06-22 at 5 48 40 pm](https://github.com/EvergenEnergy/remote-commands-handler/assets/129144052/8bef8861-149a-4a59-b959-4a3b25e7b40e)
