### PR TITLE
Improve error handling to use best practice

### DIFF
--- a/app/error_handler.py
+++ b/app/error_handler.py
@@ -18,6 +18,7 @@ class ErrorHandler:
         MQTT_ERROR = "MQTTError"
         INVALID_MESSAGE = "InvalidMessage"
         UNKNOWN_COMMAND = "UnknownCommand"
+        UNHANDLED = "UnhandledException"
 
     def __init__(self, config: Configuration, mqtt_client: mqtt.Client):
         mqtt_settings = config.get_mqtt_settings()

--- a/app/message.py
+++ b/app/message.py
@@ -16,17 +16,14 @@ class CommandMessage:
     def read(cls, message_str: str):
         try:
             message_obj = json.loads(message_str)
-            assert message_obj.get("action")
-            assert "value" in message_obj
-            return message_obj
         except JSONDecodeError as ex:
             raise InvalidMessageError(f"Message is invalid JSON syntax: {ex}")
-        except AssertionError:
+
+        if not message_obj.get("action") or "value" not in message_obj:
             raise InvalidMessageError(
                 "Message is missing required components 'action' and/or 'value'"
             )
-        except Exception as ex:
-            raise InvalidMessageError(f"Invalid message: {ex}")
+        return message_obj
 
 
 class ErrorMessage:
@@ -36,6 +33,6 @@ class ErrorMessage:
     def write(cls, message: dict):
         try:
             return json.dumps(message)
-        except Exception as ex:
+        except (TypeError, ValueError, OverflowError) as ex:
             logging.error(f"Couldn't write message {message}")
             raise InvalidMessageError(f"JSON object cannot be serialised: {ex}")

--- a/app/mqtt_reader.py
+++ b/app/mqtt_reader.py
@@ -93,6 +93,8 @@ class MqttReader:
                 for topic in self._topics:
                     logging.info("Subscribing to topic: %s", topic)
                     client.subscribe(topic)
+            else:
+                logging.error(f"Problem connecting to MQTT broker: {rc}")
 
         return inner
 

--- a/app/payload_builder.py
+++ b/app/payload_builder.py
@@ -25,6 +25,7 @@ class PayloadBuilder:
         byte_order, word_order = self.memory_order.order()
         res = BinaryPayloadBuilder(None, byte_order, word_order)
 
+        # TODO define these in a constant so we can check config has valid settings
         match self.data_type:  # noqa
             case "FLOAT64-IEEE":
                 res.add_64bit_float(self.value)

--- a/main.py
+++ b/main.py
@@ -159,10 +159,7 @@ def main():
     mqtt_reader = setup_mqtt_client(configuration, error_handler)
 
     def write_to_modbus(message):
-        try:
-            modbus_client.write_command(message["action"], message["value"])
-        except Exception as e:
-            logging.error(f"Error writing to modbus: {e}")
+        modbus_client.write_command(message["action"], message["value"])
 
     mqtt_reader.add_message_callback(write_to_modbus)
 

--- a/tests/app/test_message.py
+++ b/tests/app/test_message.py
@@ -21,7 +21,6 @@ def test_bad_cmd_message_structure():
         json_obj["foo"] = json_obj[key]
         del json_obj[key]
         json_str = json.dumps(json_obj)
-        print(json_str)
         with pytest.raises(InvalidMessageError) as ex:
             _ = CommandMessage.read(json_str)
         assert "Message is missing required components" in str(ex.value)
@@ -35,22 +34,6 @@ def test_bad_cmd_message_syntax():
         _ = CommandMessage.read(json_str)
     assert "Message is invalid JSON syntax" in str(ex.value)
     assert ex.type == InvalidMessageError
-
-
-def test_bad_cmd_message_unhandled_exception(monkeypatch):
-    def fake_json_load(_):
-        raise TypeError("unpredictable error")
-
-    with monkeypatch.context() as m:
-        m.setattr(
-            json,
-            "loads",
-            fake_json_load,
-        )
-        with pytest.raises(InvalidMessageError) as ex:
-            _ = CommandMessage.read("")
-        assert "Invalid message" in str(ex.value)
-        assert ex.type == InvalidMessageError
 
 
 def test_good_err_message():

--- a/tests/app/test_mqtt_reader.py
+++ b/tests/app/test_mqtt_reader.py
@@ -80,6 +80,16 @@ class TestMqttReader:
         callback(self.mock_mqtt_client, None, 1)
         assert "MQTT client has disconnected: 1" == str(caplog.records[0].message)
 
+    def test_fail_connect_rc(self, caplog):
+        def call_on_connect(*args):
+            callback = self.mqtt_reader._on_connect()
+            callback(self.mock_mqtt_client, None, None, 1)
+
+        self.mock_mqtt_client.connect.side_effect = call_on_connect
+        self.mqtt_reader.run()
+        self.mqtt_reader.stop()
+        assert "Problem connecting to MQTT broker: 1" == str(caplog.records[0].message)
+
     def test_unhandled_exception(self):
         def process_message(json_str):
             raise RuntimeError("didn't expect that!")

--- a/tests/app/test_mqtt_reader.py
+++ b/tests/app/test_mqtt_reader.py
@@ -10,7 +10,7 @@ import json
 
 
 class TestMqttReader:
-    def setup_class(self):
+    def setup_method(self):
         self.mock_mqtt_client = MagicMock(spec=mqtt.Client)
         self.mock_error_handler = MagicMock(spec=ErrorHandler)
         self.mqtt_reader = MqttReader(
@@ -60,7 +60,10 @@ class TestMqttReader:
         paho_msg = MQTTMessage()
         paho_msg.payload = bad_json_str.encode()
         self.mock_mqtt_client.on_message(self.mock_mqtt_client, None, paho_msg)
-        self.mock_error_handler.publish.assert_called()
+        self.mock_error_handler.publish.assert_called_with(
+            self.mock_error_handler.Category.INVALID_MESSAGE,
+            "Message is invalid JSON syntax: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)",  # noqa
+        )
 
         self.mqtt_reader.stop()
 
@@ -70,20 +73,26 @@ class TestMqttReader:
             self.mqtt_reader.run()
         assert "Cannot connect to MQTT broker" in str(ex.value)
 
-    def test_fail_connect_rc(self):
-        def call_on_connect(*args):
-            callback = self.mqtt_reader._on_connect()
-            callback(self.mock_mqtt_client, None, None, 1)
-            self.mock_error_handler.publish.assert_called()
-
-        self.mock_mqtt_client.connect.side_effect = call_on_connect
-        self.mqtt_reader.run()
-        self.mqtt_reader.stop()
-        self.mock_mqtt_client.connect.side_effect = None
-
     def test_disconnect(self, caplog):
         self.mock_mqtt_client.connect.return_value = 0
         self.mqtt_reader.run()
         callback = self.mock_mqtt_client.on_disconnect
         callback(self.mock_mqtt_client, None, 1)
         assert "MQTT client has disconnected: 1" == str(caplog.records[0].message)
+
+    def test_unhandled_exception(self):
+        def process_message(json_str):
+            raise RuntimeError("didn't expect that!")
+
+        self.mqtt_reader.add_message_callback(process_message)
+        self.mqtt_reader.run()
+
+        paho_msg = MQTTMessage()
+        json_str = json.dumps({"action": "test", "value": True})
+        paho_msg.payload = json_str.encode()
+        self.mock_mqtt_client.on_message(self.mock_mqtt_client, None, paho_msg)
+        self.mock_error_handler.publish.assert_called_with(
+            self.mock_error_handler.Category.UNHANDLED, "didn't expect that!"
+        )
+
+        self.mqtt_reader.stop()

--- a/tests/app/test_mqtt_writer.py
+++ b/tests/app/test_mqtt_writer.py
@@ -8,7 +8,7 @@ import json
 
 
 class TestMqttWriter:
-    def setup_class(self):
+    def setup_method(self):
         self.mock_mqtt_client = MagicMock(spec=mqtt.Client)
         self.mqtt_writer = MqttWriter(
             host="localhost",


### PR DESCRIPTION
## What?

- Only catch the base `Exception` class in one spot, at top-most level
- Don't use `assert` in runtime code (http://www.aleax.it/pycon16.pdf)
- Make ModbusClient write methods private so everything has to go through `write_command`
- Change tests to use `setup_method` instead of `setup_class` so all mocks are created fresh for each test

## Why?

It's not considered good practice to catch the `Exception` class, but we do want to ensure that nothing that happens during message processing can rise up and kill the main process. So I've adjusted things so that each module handles the exceptions that we can predict, and then anything else will be caught at the top-most level, inside the `_on_message` callback (which encompasses all processing from reading the incoming message, to invoking other callbacks and sending to modbus).

## Testing/Proof

CI and manual testing