### PR TITLE
UTIL-617: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,13 @@ You will need to modify the `configuration.yaml` file to match your MQTT and Mod
 - The `modbus_mappings` section allows you to configure the coils and holding registers available on your Modbus server
 - Each entry under `coils` and `holding_registers` refers to a space where Modbus will store data. The `name` for each entry will correspond to the `action` of your JSON payloads. The `address` for each entry identifies the relevant location within the Modbus server.
 - For holding registers, you must also specify the `data_type` and `byte_order` for each register.
-- The settings `site_name` and `serial_number` may be populated from environment variables of the same name, as follows:
+- Values from environment variables can be interpolated into any config setting, using the following syntax:
 ```
-site_settings:
-  site_name: $SITE_NAME
-  serial_number: $SERIAL_NUMBER
+mqtt_settings:
+  port: ${MQTT_PORT}
+  error_topic: errors/${SITE_NAME}/${DEVICE_ID}
 ```
+- When environment variables are used to populate config settings, the named environment variable must have a non-empty value.
 
 ## Contributing
 


### PR DESCRIPTION
## What?

Update the README to include current information on using env vars in config file.

## Why?

Info in README was out of date.

## Testing/Proof

No testing needed

## Open Source Reminder

Please remember that this repository is open source. Be careful to avoid including any sensitive information in your changes or your comments. If you need to discuss something sensitive, please do so through a private channel.
