### PR TITLE
Add GH token to the coveralls step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,3 +33,4 @@ jobs:
           poetry run coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What?

Add GH token to the coverall step
## Why?

Dependabot is currently failing:
https://github.com/EvergenEnergy/remote-commands-handler/pull/46
```
Running on Github Actions but GITHUB_TOKEN is not set. Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to your step config.
Traceback (most recent call last):
  File "/home/runner/.cache/pypoetry/virtualenvs/remote-comands-handler-NkRyAW_2-py3.11/lib/python3.11/site-packages/coveralls/cli.py", line 64, in main
    coverallz = Coveralls(token_required,
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pypoetry/virtualenvs/remote-comands-handler-NkRyAW_2-py3.11/lib/python3.11/site-packages/coveralls/api.py", line 49, in __init__
    self.ensure_token()
  File "/home/runner/.cache/pypoetry/virtualenvs/remote-comands-handler-NkRyAW_2-py3.11/lib/python3.11/site-packages/coveralls/api.py", line 56, in ensure_token
    raise CoverallsException(
coveralls.exception.CoverallsException: Running on Github Actions but GITHUB_TOKEN is not set. Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to your step config.
Error: Process completed with exit code 1.

```

## Testing/Proof

I think the CI will do the work to validate this change

