### PR TITLE
Raise errors on failed modbus writes

### DIFF
--- a/app/configuration.py
+++ b/app/configuration.py
@@ -255,6 +255,10 @@ def _validate_config(config: dict):
             ), "The error topic must not contain a wildcard character"
 
         mapping = config["modbus_mapping"]
+        if mapping.get("coils") is None:
+            mapping["coils"] = []
+        if mapping.get("holding_registers") is None:
+            mapping["holding_registers"] = []
         keys_defined = sum(
             [len(mapping.get(k, [])) for k in ("holding_registers", "coils")]
         )

--- a/app/modbus_client.py
+++ b/app/modbus_client.py
@@ -50,8 +50,12 @@ class ModbusClient:
         if coil_configuration:
             try:
                 self._client.connect()
-                self._client.write_coils(coil_configuration.address[0], value)
+                response = self._client.write_coils(
+                    coil_configuration.address[0], value
+                )
                 self._client.close()
+                if response.isError():
+                    raise ModbusClientError(response)
                 logging.debug(f"wrote to coil {name}, value: {value!r}")
                 return len(value)
             except ModbusException as ex:
@@ -62,8 +66,12 @@ class ModbusClient:
         if coil_configuration:
             try:
                 self._client.connect()
-                self._client.write_coil(coil_configuration.address[0], value, 1)
+                response = self._client.write_coil(
+                    coil_configuration.address[0], value, 1
+                )
                 self._client.close()
+                if response.isError():
+                    raise ModbusClientError(response)
                 logging.debug(f"wrote to coil {name}, value: {value!r}")
                 return 1
             except ModbusException as ex:
@@ -78,11 +86,13 @@ class ModbusClient:
                 raise InvalidMessageError(ex)
             try:
                 self._client.connect()
-                self._client.write_registers(
+                response = self._client.write_registers(
                     holding_register_configuration.address[0], payload, 1
                 )
                 self._client.close()
                 logging.debug(f"wrote to register {name}, value: {value!r}")
+                if response.isError():
+                    raise ModbusClientError(response)
                 return 1
             except ModbusException as ex:
                 raise ModbusClientError(ex)
@@ -102,7 +112,7 @@ class ModbusClient:
                 self.error_handler.publish(
                     self.error_handler.Category.MODBUS_ERROR, str(ex)
                 )
-                raise ex
+                return 0
 
         if message.input_type == InputTypes.REGISTER:
             try:
@@ -116,7 +126,7 @@ class ModbusClient:
                 self.error_handler.publish(
                     self.error_handler.Category.MODBUS_ERROR, str(ex)
                 )
-                raise ex
+                return 0
 
         return sent
 

--- a/tests/app/test_modbus_client.py
+++ b/tests/app/test_modbus_client.py
@@ -173,3 +173,11 @@ class TestModbusClient:
         self.mock_error_handler.publish.assert_called_with(
             self.mock_error_handler.Category.MODBUS_ERROR, "bad response"
         )
+
+        self.mock_client.write_coils.return_value = MockBadModbusResponse()
+        self.modbus_client.write_command(
+            CommandMessage(test_coil.name, [True], self.configuration)
+        )
+        self.mock_error_handler.publish.assert_called_with(
+            self.mock_error_handler.Category.MODBUS_ERROR, "bad response"
+        )

--- a/tests/config/test_configuration.py
+++ b/tests/config/test_configuration.py
@@ -200,6 +200,11 @@ def test_validate_config_data():
             _validate_config(c)
         assert "address" in str(ex.value)
 
+    for datatype in ("coils", "holding_registers"):
+        c = deepcopy(config)
+        del c["modbus_mapping"][datatype]
+        _validate_config(c)
+
 
 def test_key_error_in_config_parsing(monkeypatch):
     """


### PR DESCRIPTION
## What?

* Check the response when writing to modbus and raise an error if the response indicates an error
* Don't re-raise errors after publishing an error
* Allow configurations with no coils
* Adjust tests

## Why?

We were missing errors by ignoring the response object returned from modbus writes, and were too restrictive on potential configs.

## Testing/Proof

Covered by automated tests

## Open Source Reminder

Please remember that this repository is open source. Be careful to avoid including any sensitive information in your changes or your comments. If you need to discuss something sensitive, please do so through a private channel.
