### PR TITLE
Add sign inversion

### DIFF
--- a/app/configuration.py
+++ b/app/configuration.py
@@ -279,5 +279,9 @@ def _validate_config(config: dict):
                 assert (
                     key in ref
                 ), f"Holding register reference #{index} has no config setting for {key!r}"
+            if ref.get("invert"):
+                assert not ref["data_type"].startswith(
+                    "UINT"
+                ), f"Holding register #{index} cannot set invert=True on an unsigned integer"
     except (AssertionError, TypeError, ValueError) as ex:
         raise ConfigurationFileInvalidError(ex)

--- a/app/configuration.py
+++ b/app/configuration.py
@@ -54,6 +54,7 @@ class HoldingRegister:
     data_type: str
     scale: float
     address: list[int]
+    invert: bool = False
 
 
 @dataclass
@@ -213,6 +214,7 @@ def _holding_register_from_yaml_data(data: dict):
             register["data_type"],
             register.get("scale", 1.0),
             register["address"],
+            register.get("invert", False),
         )
         holding_registers.append(register)
 

--- a/app/configuration.py
+++ b/app/configuration.py
@@ -54,7 +54,7 @@ class HoldingRegister:
     data_type: str
     scale: float
     address: list[int]
-    invert: bool = False
+    invert_sign: bool = False
 
 
 @dataclass
@@ -214,7 +214,7 @@ def _holding_register_from_yaml_data(data: dict):
             register["data_type"],
             register.get("scale", 1.0),
             register["address"],
-            register.get("invert", False),
+            register.get("invert_sign", False),
         )
         holding_registers.append(register)
 
@@ -279,9 +279,9 @@ def _validate_config(config: dict):
                 assert (
                     key in ref
                 ), f"Holding register reference #{index} has no config setting for {key!r}"
-            if ref.get("invert"):
+            if ref.get("invert_sign"):
                 assert not ref["data_type"].startswith(
                     "UINT"
-                ), f"Holding register #{index} cannot set invert=True on an unsigned integer"
+                ), f"Holding register #{index} cannot set invert_sign=True on an unsigned integer"
     except (AssertionError, TypeError, ValueError) as ex:
         raise ConfigurationFileInvalidError(ex)

--- a/app/message.py
+++ b/app/message.py
@@ -75,6 +75,8 @@ class MessageTransformer:
             value = configuration.scale * value
             if "INT" in configuration.data_type:
                 value = int(value)
+        if configuration.invert:
+            value = 0 - value
         logging.debug(
             f"transformed value {value} with config {configuration} to {tvalue}"
         )

--- a/app/message.py
+++ b/app/message.py
@@ -75,8 +75,8 @@ class MessageTransformer:
             value = configuration.scale * value
             if "INT" in configuration.data_type:
                 value = int(value)
-        if configuration.invert:
-            value = 0 - value
+        if configuration.invert_sign:
+            value = -1 * value
         logging.debug(
             f"transformed value {value} with config {configuration} to {tvalue}"
         )

--- a/app/modbus_client.py
+++ b/app/modbus_client.py
@@ -23,6 +23,7 @@ Note:
 """
 
 import logging
+import struct
 
 from pymodbus.client import ModbusTcpClient
 from pymodbus.exceptions import ModbusException
@@ -82,7 +83,7 @@ class ModbusClient:
         if holding_register_configuration:
             try:
                 payload = _build_register_payload(holding_register_configuration, value)
-            except (AttributeError, RuntimeError) as ex:
+            except (AttributeError, RuntimeError, struct.error) as ex:
                 raise InvalidMessageError(ex)
             try:
                 self._client.connect()

--- a/tests/app/test_message.py
+++ b/tests/app/test_message.py
@@ -70,6 +70,19 @@ class TestCommandMessage:
         msg.transform()
         assert msg.value == 34.56
 
+    def test_invert(self):
+        msg = CommandMessage(
+            "evgBatteryTargetPowerWattsInverted", 4000, self.configuration
+        )
+        msg.transform()
+        assert msg.value == -4000
+
+    def test_scale_and_invert(self):
+        msg = CommandMessage("evgBatteryScaleAndInvert", 4567, self.configuration)
+        msg.transform()
+        assert isinstance(msg.value, int)
+        assert msg.value == -456
+
 
 class TestErrorMessage:
     def test_good_err_message(self):

--- a/tests/config/example_configuration.yaml
+++ b/tests/config/example_configuration.yaml
@@ -27,6 +27,18 @@ modbus_mapping:
       data_type: FLOAT32
       scale: 0.01
       address: [3, 4]
+    - name: evgBatteryTargetPowerWattsInverted
+      byte_order: AB
+      data_type: FLOAT32
+      scale: 1.0
+      address: [5, 6]
+      invert: True
+    - name: evgBatteryScaleAndInvert
+      byte_order: AB
+      data_type: INT32
+      scale: 0.1
+      address: [7, 8]
+      invert: True
   coils:
     - name: evgBatteryModeCoil
       address: [10]

--- a/tests/config/example_configuration.yaml
+++ b/tests/config/example_configuration.yaml
@@ -32,13 +32,13 @@ modbus_mapping:
       data_type: FLOAT32
       scale: 1.0
       address: [5, 6]
-      invert: True
+      invert_sign: True
     - name: evgBatteryScaleAndInvert
       byte_order: AB
       data_type: INT32
       scale: 0.1
       address: [7, 8]
-      invert: True
+      invert_sign: True
   coils:
     - name: evgBatteryModeCoil
       address: [10]

--- a/tests/config/test_configuration.py
+++ b/tests/config/test_configuration.py
@@ -85,13 +85,13 @@ def test_get_holding_registers():
     assert evg_battery_target_soc_percent.scale == 0.01
     assert evg_battery_target_soc_percent.address == [3, 4]
     assert evg_battery_target_soc_percent.input_type == InputTypes.REGISTER
-    assert evg_battery_target_soc_percent.invert is False
+    assert evg_battery_target_soc_percent.invert_sign is False
 
     evg_battery_target_power_watts = configuration.get_holding_register(
         "evgBatteryTargetPowerWattsInverted"
     )
     assert evg_battery_target_power_watts.scale == 1.0
-    assert evg_battery_target_power_watts.invert is True
+    assert evg_battery_target_power_watts.invert_sign is True
 
 
 def test_able_to_get_mqtt_settings():
@@ -220,11 +220,11 @@ def test_validate_config_data():
 
     inverting_unsigned_int = deepcopy(config)
     reg = inverting_unsigned_int["modbus_mapping"]["holding_registers"][0]
-    reg["invert"] = True
+    reg["invert_sign"] = True
     reg["data_type"] = "UINT16"
     with pytest.raises(ConfigurationFileInvalidError) as ex:
         _validate_config(inverting_unsigned_int)
-    assert "cannot set invert=True" in str(ex.value)
+    assert "cannot set invert_sign=True" in str(ex.value)
 
 
 def test_key_error_in_config_parsing(monkeypatch):

--- a/tests/config/test_configuration.py
+++ b/tests/config/test_configuration.py
@@ -150,7 +150,7 @@ def test_get_coils():
 
 def test_get_registers():
     coils = []
-    holding_registers = [HoldingRegister("test", "AB", "STR", 1.0, [0])]
+    holding_registers = [HoldingRegister("test", "AB", "INT16", 1.0, [0])]
     mqtt_settings = MqttSettings("test", 100, "test")
     modbus_settings = ModbusSettings("localhost", 10)
     site_settings = SiteSettings("testsite", "testdevice")
@@ -217,6 +217,14 @@ def test_validate_config_data():
         c = deepcopy(config)
         del c["modbus_mapping"][datatype]
         _validate_config(c)
+
+    inverting_unsigned_int = deepcopy(config)
+    reg = inverting_unsigned_int["modbus_mapping"]["holding_registers"][0]
+    reg["invert"] = True
+    reg["data_type"] = "UINT16"
+    with pytest.raises(ConfigurationFileInvalidError) as ex:
+        _validate_config(inverting_unsigned_int)
+    assert "cannot set invert=True" in str(ex.value)
 
 
 def test_key_error_in_config_parsing(monkeypatch):

--- a/tests/config/test_configuration.py
+++ b/tests/config/test_configuration.py
@@ -85,6 +85,13 @@ def test_get_holding_registers():
     assert evg_battery_target_soc_percent.scale == 0.01
     assert evg_battery_target_soc_percent.address == [3, 4]
     assert evg_battery_target_soc_percent.input_type == InputTypes.REGISTER
+    assert evg_battery_target_soc_percent.invert is False
+
+    evg_battery_target_power_watts = configuration.get_holding_register(
+        "evgBatteryTargetPowerWattsInverted"
+    )
+    assert evg_battery_target_power_watts.scale == 1.0
+    assert evg_battery_target_power_watts.invert is True
 
 
 def test_able_to_get_mqtt_settings():

--- a/tests/end-to-end/configuration.yaml
+++ b/tests/end-to-end/configuration.yaml
@@ -77,13 +77,13 @@ modbus_mapping:
       data_type: INT16
       scale: 1.0
       address: [60]
-      invert: True
+      invert_sign: True
     - name: testScaleAndInvert
       byte_order: AB
       data_type: FLOAT32-IEEE
       scale: 0.1
       address: [62, 63]
-      invert: True
+      invert_sign: True
   coils:
     - name: evgBatteryModeCoil
       address: [501]

--- a/tests/end-to-end/configuration.yaml
+++ b/tests/end-to-end/configuration.yaml
@@ -72,6 +72,18 @@ modbus_mapping:
       data_type: FLOAT32-IEEE
       scale: 0.01
       address: [55, 56]
+    - name: testInvert
+      byte_order: AB
+      data_type: INT16
+      scale: 1.0
+      address: [60]
+      invert: True
+    - name: testScaleAndInvert
+      byte_order: AB
+      data_type: FLOAT32-IEEE
+      scale: 0.1
+      address: [62, 63]
+      invert: True
   coils:
     - name: evgBatteryModeCoil
       address: [501]

--- a/tests/end-to-end/test_send_and_read_back_command_values.py
+++ b/tests/end-to-end/test_send_and_read_back_command_values.py
@@ -285,8 +285,7 @@ def test_read_error_messages(mqtt_client: mqtt.Client, modbus_client: ModbusTcpC
     assert "Message is missing required components" in line1
     assert "UnknownCommand" in line2
     assert "No coil or register found to match 'NotARealCoil'" in line2
-    # TODO This should become a specific exception when we have better register validation
-    assert "UnhandledException" in line3
+    assert "InvalidMessage" in line3
     assert "format requires -32768 <= number <= 32767" in line3
 
     os.remove(msg_log)


### PR DESCRIPTION
## What?

* Add a config setting which inverts the sign of values before writing to modbus
* Add config validation so you can't do this on an unsigned integer field
* Catch struct.error exceptions which happen if you try to do this anyway
* Add unit tests
* Add e2e tests

## Why?

Needed so that values can be inverted when passing between systems which represent import/export values with opposite signs

## Testing/Proof

Automated tests

## Open Source Reminder

Please remember that this repository is open source. Be careful to avoid including any sensitive information in your changes or your comments. If you need to discuss something sensitive, please do so through a private channel.
