### PR TITLE
Use evergen docker image for pymodbus

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
         max-size: 10m
   pymodbus:
     container_name: pymodbus
-    image: ghcr.io/pymodbus-dev/pymodbus:v3.1.0
+    image: ghcr.io/evergenenergy/pymodbus-image:main
     command:
       - pymodbus.server
       - --host


### PR DESCRIPTION
## What?

Use the pymodbus image generated in https://github.com/EvergenEnergy/pymodbus-image/

## Why?

The pymodbus project are no longer produced a docker image.

## Testing/Proof

E2E tests pass when running this image in docker-compose