### PR TITLE
Expect a list of commands as MQTT message payload

### DIFF
--- a/app/message.py
+++ b/app/message.py
@@ -12,6 +12,26 @@ from app.exceptions import InvalidMessageError, UnknownCommandError
 from app.configuration import Configuration, InputTypes
 
 
+class CommandMessageList:
+    """Create a CommandMessage object and retrieve its configuration."""
+
+    @classmethod
+    def read(cls, message_str: str):
+        try:
+            message_list = json.loads(message_str)
+        except JSONDecodeError as ex:
+            raise InvalidMessageError(f"Message is invalid JSON syntax: {ex}")
+
+        for message_obj in message_list:
+            if not isinstance(message_obj, dict):
+                raise InvalidMessageError("Message object must be a dict")
+            if not message_obj.get("action") or "value" not in message_obj:
+                raise InvalidMessageError(
+                    "Message is missing required components 'action' and/or 'value'"
+                )
+        return message_list
+
+
 class CommandMessage:
     """Create a CommandMessage object and retrieve its configuration."""
 
@@ -33,19 +53,6 @@ class CommandMessage:
         if self.input_type == InputTypes.REGISTER:
             self.value = MessageTransformer.transform(self.configuration, self.value)
             MessageValidator.validate(self.input_type, self.value)
-
-    @classmethod
-    def read(cls, message_str: str):
-        try:
-            message_obj = json.loads(message_str)
-        except JSONDecodeError as ex:
-            raise InvalidMessageError(f"Message is invalid JSON syntax: {ex}")
-
-        if not message_obj.get("action") or "value" not in message_obj:
-            raise InvalidMessageError(
-                "Message is missing required components 'action' and/or 'value'"
-            )
-        return message_obj
 
 
 class MessageValidator:

--- a/app/mqtt_reader.py
+++ b/app/mqtt_reader.py
@@ -9,7 +9,7 @@ from typing import Callable
 
 import paho.mqtt.client as mqtt
 
-from app.message import CommandMessage
+from app.message import CommandMessage, CommandMessageList
 from app.configuration import Configuration
 from app.exceptions import InvalidMessageError, UnknownCommandError
 from app.error_handler import ErrorHandler
@@ -65,15 +65,20 @@ class MqttReader:
 
     def _on_message(self):
         def inner(_client, _userdata, message):
+            msg_topic = message.topic
+            msg_str = ""
+            msg_obj_list = []
             try:
                 try:
                     msg_str = _decode_message(message)
-                    msg_dict = CommandMessage.read(msg_str)
-                    msg_obj = CommandMessage(
-                        msg_dict["action"], msg_dict["value"], self.configuration
-                    )
-                    msg_obj.validate()
-                    msg_obj.transform()
+                    msg_list = CommandMessageList.read(msg_str)
+                    for msg_dict in msg_list:
+                        msg_obj = CommandMessage(
+                            msg_dict["action"], msg_dict["value"], self.configuration
+                        )
+                        msg_obj.validate()
+                        msg_obj.transform()
+                        msg_obj_list.append(msg_obj)
                 except InvalidMessageError as ex:
                     self.error_handler.publish(
                         self.error_handler.Category.INVALID_MESSAGE, str(ex)
@@ -84,13 +89,16 @@ class MqttReader:
                         self.error_handler.Category.UNKNOWN_COMMAND, str(ex)
                     )
                     return
-                for callback in self._on_message_callbacks:
-                    callback(msg_obj)
+                for msg_obj in msg_obj_list:
+                    for callback in self._on_message_callbacks:
+                        callback(msg_obj)
             # In general it's not good practice to catch Exception, but we're doing so here
             # in order to trap unhandled exceptions occurring within message processing,
             # and prevent them rising up to the main loop.
             # If these occur, the cause should be identified and code changed to catch them.
             except Exception as ex:
+                logging.error(f"Encountered error {ex} on topic {msg_topic}")
+                logging.info(msg_str)
                 self.error_handler.publish(
                     self.error_handler.Category.UNHANDLED, str(ex)
                 )

--- a/tests/app/test_message.py
+++ b/tests/app/test_message.py
@@ -4,7 +4,7 @@ import pytest
 from datetime import datetime
 import json
 from app.configuration import Configuration
-from app.message import CommandMessage, ErrorMessage
+from app.message import CommandMessageList, CommandMessage, ErrorMessage
 from app.exceptions import InvalidMessageError, UnknownCommandError
 
 
@@ -15,11 +15,12 @@ class TestCommandMessage:
         )
 
     def test_good_cmd_message(self):
-        json_obj = {"action": "somecoil", "value": True}
+        json_obj = [{"action": "somecoil", "value": True}]
         json_str = json.dumps(json_obj)
-        read_msg = CommandMessage.read(json_str)
-        assert "action" in read_msg
-        assert "value" in read_msg
+        read_msg = CommandMessageList.read(json_str)
+        assert len(read_msg) == 1
+        assert "action" in read_msg[0]
+        assert "value" in read_msg[0]
 
     def test_unknown_command(self):
         with pytest.raises(UnknownCommandError) as ex:
@@ -34,9 +35,9 @@ class TestCommandMessage:
         for key in ("action", "value"):
             json_obj["foo"] = json_obj[key]
             del json_obj[key]
-            json_str = json.dumps(json_obj)
+            json_str = json.dumps([json_obj])
             with pytest.raises(InvalidMessageError) as ex:
-                _ = CommandMessage.read(json_str)
+                _ = CommandMessageList.read(json_str)
             assert "Message is missing required components" in str(ex.value)
             assert ex.type == InvalidMessageError
             json_obj[key] = json_obj["foo"]
@@ -44,7 +45,7 @@ class TestCommandMessage:
     def test_bad_cmd_message_syntax(self):
         json_str = "not a real json string"
         with pytest.raises(InvalidMessageError) as ex:
-            _ = CommandMessage.read(json_str)
+            _ = CommandMessageList.read(json_str)
         assert "Message is invalid JSON syntax" in str(ex.value)
         assert ex.type == InvalidMessageError
 

--- a/tests/app/test_message.py
+++ b/tests/app/test_message.py
@@ -22,6 +22,19 @@ class TestCommandMessage:
         assert "action" in read_msg[0]
         assert "value" in read_msg[0]
 
+    def test_multiple_cmd_messages(self):
+        json_obj = [
+            {"action": "somecoil", "value": True},
+            {"action": "someregister", "value": 42.3},
+        ]
+        json_str = json.dumps(json_obj)
+        read_msgs = CommandMessageList.read(json_str)
+        assert len(read_msgs) == 2
+        assert read_msgs[0].get("action") == "somecoil"
+        assert read_msgs[0].get("value") is True
+        assert read_msgs[1].get("action") == "someregister"
+        assert read_msgs[1].get("value") == 42.3
+
     def test_unknown_command(self):
         with pytest.raises(UnknownCommandError) as ex:
             CommandMessage("bad_register", 54, self.configuration)

--- a/tests/app/test_mqtt_reader.py
+++ b/tests/app/test_mqtt_reader.py
@@ -45,10 +45,10 @@ class TestMqttReader:
         self.mock_mqtt_client.subscribe.call_count == 1
 
         # Pretend that the MQTT broker received a message and our callback is called
-        json_obj = {"action": "evgBatteryModeCoil", "value": True}
+        json_obj = [{"action": "evgBatteryModeCoil", "value": True}]
         json_str = json.dumps(json_obj)
         msg_obj = CommandMessage(
-            json_obj["action"], json_obj["value"], self.configuration
+            json_obj[0]["action"], json_obj[0]["value"], self.configuration
         )
         paho_msg = MQTTMessage()
         paho_msg.payload = json_str.encode()
@@ -74,12 +74,30 @@ class TestMqttReader:
             "Message is invalid JSON syntax: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)",  # noqa
         )
 
+        bad_json_str = '["list","without","dict"]'
+        paho_msg = MQTTMessage()
+        paho_msg.payload = bad_json_str.encode()
+        self.mock_mqtt_client.on_message(self.mock_mqtt_client, None, paho_msg)
+        self.mock_error_handler.publish.assert_called_with(
+            self.mock_error_handler.Category.INVALID_MESSAGE,
+            "Message object must be a dict",
+        )
+
+        bad_json_str = '[{"action":"but no value"}]'
+        paho_msg = MQTTMessage()
+        paho_msg.payload = bad_json_str.encode()
+        self.mock_mqtt_client.on_message(self.mock_mqtt_client, None, paho_msg)
+        self.mock_error_handler.publish.assert_called_with(
+            self.mock_error_handler.Category.INVALID_MESSAGE,
+            "Message is missing required components 'action' and/or 'value'",
+        )
+
         self.mqtt_reader.stop()
 
     def test_unknown_message(self):
         self.mqtt_reader.run()
 
-        unknown_msg = json.dumps({"action": "noSuchCoil", "value": False})
+        unknown_msg = json.dumps([{"action": "noSuchCoil", "value": False}])
         paho_msg = MQTTMessage()
         paho_msg.payload = unknown_msg.encode()
         self.mock_mqtt_client.on_message(self.mock_mqtt_client, None, paho_msg)
@@ -121,7 +139,7 @@ class TestMqttReader:
         self.mqtt_reader.run()
 
         paho_msg = MQTTMessage()
-        json_str = json.dumps({"action": "evgBatteryModeCoil", "value": True})
+        json_str = json.dumps([{"action": "evgBatteryModeCoil", "value": True}])
         paho_msg.payload = json_str.encode()
         self.mock_mqtt_client.on_message(self.mock_mqtt_client, None, paho_msg)
         self.mock_error_handler.publish.assert_called_with(

--- a/tests/end-to-end/test_send_and_read_back_command_values.py
+++ b/tests/end-to-end/test_send_and_read_back_command_values.py
@@ -35,13 +35,11 @@ def config():
     yield Configuration.from_file("tests/end-to-end/configuration.yaml")
 
 
-def publish_message(mqtt_client: mqtt.Client, *args: str):
-    print(args)
-    message_list = []
-    for msg_pair in args:
-        message_list.append({"action": msg_pair[0], "value": msg_pair[1]})
-    message = json.dumps(message_list)
-    print(message)
+def publish_message(mqtt_client: mqtt.Client, *cmd_pairs: str):
+    cmd_list = []
+    for cmd in cmd_pairs:
+        cmd_list.append({"action": cmd[0], "value": cmd[1]})
+    message = json.dumps(cmd_list)
 
     mqtt_client.publish("commands/test", message)
 

--- a/tests/end-to-end/test_send_and_read_back_command_values.py
+++ b/tests/end-to-end/test_send_and_read_back_command_values.py
@@ -36,7 +36,7 @@ def config():
 
 
 def publish_message(mqtt_client: mqtt.Client, name: str, value: str):
-    message_dictionary = {"action": name, "value": value}
+    message_dictionary = [{"action": name, "value": value}]
     message = json.dumps(message_dictionary)
 
     mqtt_client.publish("commands/test", message)
@@ -263,7 +263,7 @@ def test_read_error_messages(mqtt_client: mqtt.Client, modbus_client: ModbusTcpC
 
     # Generate two error messages by sending bad commands
     def send_bad_command(msg_obj):
-        message = json.dumps(msg_obj)
+        message = json.dumps([msg_obj])
         mqtt_client.publish("commands/test", message)
 
     send_bad_command({"invalid": ["message", "structure"]})


### PR DESCRIPTION
## What?

* add a `CommandMessageList` class and move the `read` method there
* update all tests to send a list of commands as JSON payload
* add some tests with multiple commands

## Why?

Being able to send multiple commands in a single message increases efficiency and allows for values of different registers to be tightly linked together.

## Testing/Proof

Tested in a local deployment with list-format messages being sent from the cloud and standby service.
